### PR TITLE
Removed unused NLog reference

### DIFF
--- a/Passbook.Generator/Passbook.Generator.csproj
+++ b/Passbook.Generator/Passbook.Generator.csproj
@@ -58,10 +58,6 @@
     <Reference Include="Newtonsoft.Json">
       <HintPath>..\packages\Newtonsoft.Json.4.5.7\lib\net40\Newtonsoft.Json.dll</HintPath>
     </Reference>
-    <Reference Include="NLog, Version=2.0.1.0, Culture=neutral, PublicKeyToken=5120e14c03d0593c, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\PassVerse\packages\NLog.2.0.1.2\lib\net45\NLog.dll</HintPath>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Drawing" />


### PR DESCRIPTION
This fixes a compiler warning I was seeing.