### PR TITLE
Add optional major and minor property to Beacon #26

### DIFF
--- a/Passbook.Generator/PassGeneratorRequest.cs
+++ b/Passbook.Generator/PassGeneratorRequest.cs
@@ -290,9 +290,9 @@ namespace Passbook.Generator
             this.RelevantLocations.Add(new RelevantLocation() { Latitude = latitude, Longitude = longitude, RelevantText = relevantText });
         }
 
-        public void AddBeacon(string proximityUUID, string relevantText)
+        public void AddBeacon(string proximityUUID, string relevantText, int? major = null, int? minor = null)
         {
-            this.RelevantBeacons.Add(new RelevantBeacon() { ProximityUUID = proximityUUID, RelevantText = relevantText });
+            this.RelevantBeacons.Add(new RelevantBeacon() { ProximityUUID = proximityUUID, RelevantText = relevantText, Major = major, Minor = minor});
         }
 
         public virtual void PopulateFields()

--- a/Passbook.Generator/RelevantBeacon.cs
+++ b/Passbook.Generator/RelevantBeacon.cs
@@ -18,6 +18,8 @@ namespace Passbook.Generator
         /// Optional. Text displayed on the lock screen when the pass is currently relevant.
         /// </summary>
         public string RelevantText { get; set; }
+        public int? Major { get; set; }
+        public int? Minor{ get; set; }
 
         public void Write(JsonWriter writer)
         {
@@ -32,6 +34,18 @@ namespace Passbook.Generator
             {
                 writer.WritePropertyName("relevantText");
                 writer.WriteValue(RelevantText);
+            }
+
+            if (Minor.HasValue)
+            {
+                writer.WritePropertyName("minor");
+                writer.WriteValue(Minor);
+            }
+
+            if (Major.HasValue)
+            {
+                writer.WritePropertyName("major");
+                writer.WriteValue(Major);
             }
 
             writer.WriteEndObject();


### PR DESCRIPTION
Saw Issue #26 and thought it looked like an easy place to help out. I followed the Passbook spec for [Beacon Dictionary Keys](https://developer.apple.com/library/ios/documentation/UserExperience/Reference/PassKit_Bundle/Chapters/LowerLevel.html#//apple_ref/doc/uid/TP40012026-CH3-SW4)

CAVET: I do not have any iBeacons to test this