### PR TITLE
#42 properly formatting DateTime field with "o"

### DIFF
--- a/Passbook.Generator/PassGeneratorRequest.cs
+++ b/Passbook.Generator/PassGeneratorRequest.cs
@@ -569,7 +569,7 @@ namespace Passbook.Generator
 			if (RelevantDate.HasValue)
 			{
 				writer.WritePropertyName("relevantDate");
-				writer.WriteValue(RelevantDate.Value.ToString("yyyy-MM-ddTHH:mm:sszzz"));
+				writer.WriteValue(RelevantDate.Value.ToString("o"));
 			}
 
 			if (MaxDistance.HasValue)
@@ -727,7 +727,7 @@ namespace Passbook.Generator
 			if (ExpirationDate.HasValue)
 			{
 				writer.WritePropertyName("expirationDate");
-				writer.WriteValue(ExpirationDate.Value.ToString("yyyy-MM-ddTHH:mm:sszzz"));
+				writer.WriteValue(ExpirationDate.Value.ToString("o"));
 			}
 
 			if (Voided.HasValue)


### PR DESCRIPTION
full DateTime fields should be formatted with "o", which preserves timezone information