### PR TITLE
Reverting relevantDate export format to the previous one

### DIFF
--- a/Passbook.Generator/PassGeneratorRequest.cs
+++ b/Passbook.Generator/PassGeneratorRequest.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Linq;
 using Newtonsoft.Json;
 using Passbook.Generator.Fields;
@@ -569,7 +569,7 @@ namespace Passbook.Generator
 			if (RelevantDate.HasValue)
 			{
 				writer.WritePropertyName("relevantDate");
-				writer.WriteValue(RelevantDate.Value.ToString("o"));
+				writer.WriteValue(RelevantDate.Value.ToString("yyyy-MM-ddTHH:mm:sszzz"));
 			}
 
 			if (MaxDistance.HasValue)


### PR DESCRIPTION
Reverting relevantDate export format to the previous one.
Change based on current issues opening a passbook:
"Unable to parse relevantDate 2016-04-08T09:16:45.0789286+02:00 as a date. We expect dates in "W3C date time stamp format", either "Complete date plus hours and minutes" or "Complete date plus hours, minutes and seconds". For example, 1980-05-07T10:30-05:00."