### PR TITLE
replace System.Drawing dep with simple color parsing

### DIFF
--- a/Passbook.Generator/PassGeneratorRequest.cs
+++ b/Passbook.Generator/PassGeneratorRequest.cs
@@ -3,7 +3,7 @@ using Passbook.Generator.Fields;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Drawing;
+using System.Globalization;
 using System.Security.Cryptography.X509Certificates;
 
 namespace Passbook.Generator
@@ -592,8 +592,26 @@ namespace Passbook.Generator
         {
             if (!string.IsNullOrEmpty(color) && color.Substring(0, 1) == "#")
             {
-                Color c = ColorTranslator.FromHtml(color);
-                return string.Format("rgb({0},{1},{2})", c.R, c.G, c.B);
+                int r, g, b;
+
+                if (color.Length == 3)
+                {
+                    r = int.Parse(color.Substring(1, 1), NumberStyles.HexNumber);
+                    g = int.Parse(color.Substring(2, 1), NumberStyles.HexNumber);
+                    b = int.Parse(color.Substring(3, 1), NumberStyles.HexNumber);
+                }
+                else if (color.Length >= 6)
+                {
+                    r = int.Parse(color.Substring(1, 2), NumberStyles.HexNumber);
+                    g = int.Parse(color.Substring(2, 2), NumberStyles.HexNumber);
+                    b = int.Parse(color.Substring(3, 2), NumberStyles.HexNumber);
+                }
+                else
+                {
+                    throw new ArgumentException("use #rgb or #rrggbb for color values", color);
+                }
+
+                return $"rgb({r},{g},{b})";
             }
             else
             {

--- a/Passbook.Generator/PassGeneratorRequest.cs
+++ b/Passbook.Generator/PassGeneratorRequest.cs
@@ -603,8 +603,8 @@ namespace Passbook.Generator
                 else if (color.Length >= 6)
                 {
                     r = int.Parse(color.Substring(1, 2), NumberStyles.HexNumber);
-                    g = int.Parse(color.Substring(2, 2), NumberStyles.HexNumber);
-                    b = int.Parse(color.Substring(3, 2), NumberStyles.HexNumber);
+                    g = int.Parse(color.Substring(3, 2), NumberStyles.HexNumber);
+                    b = int.Parse(color.Substring(5, 2), NumberStyles.HexNumber);
                 }
                 else
                 {

--- a/Passbook.Generator/Passbook.Generator.csproj
+++ b/Passbook.Generator/Passbook.Generator.csproj
@@ -6,7 +6,6 @@
 
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
-    <PackageReference Include="System.Drawing.Common" Version="4.5.1" />
     <PackageReference Include="System.Security.Cryptography.Pkcs" Version="4.5.1" />
   </ItemGroup>
 


### PR DESCRIPTION
The System.Drawing.Common package has dependencies
on win32 specific packages. I didn't test the `ColorTranslator`
on Linux, but thought it would be best to replace it and
remove a potential cross-platform compatibility problem.

Initial tests with my application on Linux look good. Package
generate works signing appears to be valid.