### PR TITLE
Set MachineKeySet flag for certificates with no password

### DIFF
--- a/Passbook.Generator/PassGenerator.cs
+++ b/Passbook.Generator/PassGenerator.cs
@@ -356,17 +356,8 @@ namespace Passbook.Generator
         {
             Trace.TraceInformation("Opening Certificate: [{0}] bytes with password [{1}]", bytes.Length, password);
 
-            X509Certificate2 certificate = null;
-
-            if (password == null)
-            {
-                certificate = new X509Certificate2(bytes);
-            }
-            else
-            {
-                X509KeyStorageFlags flags = X509KeyStorageFlags.MachineKeySet | X509KeyStorageFlags.Exportable;
-                certificate = new X509Certificate2(bytes, password, flags);
-            }
+            X509KeyStorageFlags flags = X509KeyStorageFlags.MachineKeySet | X509KeyStorageFlags.Exportable;
+            X509Certificate2 certificate = new X509Certificate2(bytes, password, flags);
 
             return certificate;
         }


### PR DESCRIPTION
Fixing #110 

Password can be null with the constructor that takes the flag