### PR TITLE
Support .NET Core 3.1/ .NET 5 / .NET 6

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,132 @@
+###############################
+# Core EditorConfig Options   #
+###############################
+root = true
+# All files
+[*]
+indent_style = space
+
+# XML project files
+[*.{csproj,vbproj,vcxproj,vcxproj.filters,proj,projitems,shproj}]
+indent_size = 2
+
+# XML config files
+[*.{props,targets,ruleset,config,nuspec,resx,vsixmanifest,vsct}]
+indent_size = 2
+
+# Code files
+[*.{cs,csx,vb,vbx}]
+indent_size = 4
+insert_final_newline = true
+charset = utf-8-bom
+###############################
+# .NET Coding Conventions     #
+###############################
+[*.{cs,vb}]
+# Organize usings
+dotnet_sort_system_directives_first = true
+# this. preferences
+dotnet_style_qualification_for_field = false:silent
+dotnet_style_qualification_for_property = false:silent
+dotnet_style_qualification_for_method = false:silent
+dotnet_style_qualification_for_event = false:silent
+# Language keywords vs BCL types preferences
+dotnet_style_predefined_type_for_locals_parameters_members = true:silent
+dotnet_style_predefined_type_for_member_access = true:silent
+# Parentheses preferences
+dotnet_style_parentheses_in_arithmetic_binary_operators = always_for_clarity:silent
+dotnet_style_parentheses_in_relational_binary_operators = always_for_clarity:silent
+dotnet_style_parentheses_in_other_binary_operators = always_for_clarity:silent
+dotnet_style_parentheses_in_other_operators = never_if_unnecessary:silent
+# Modifier preferences
+dotnet_style_require_accessibility_modifiers = for_non_interface_members:silent
+dotnet_style_readonly_field = true:suggestion
+# Expression-level preferences
+dotnet_style_object_initializer = true:suggestion
+dotnet_style_collection_initializer = true:suggestion
+dotnet_style_explicit_tuple_names = true:suggestion
+dotnet_style_null_propagation = true:suggestion
+dotnet_style_coalesce_expression = true:suggestion
+dotnet_style_prefer_is_null_check_over_reference_equality_method = true:silent
+dotnet_style_prefer_inferred_tuple_names = true:suggestion
+dotnet_style_prefer_inferred_anonymous_type_member_names = true:suggestion
+dotnet_style_prefer_auto_properties = true:silent
+dotnet_style_prefer_conditional_expression_over_assignment = true:silent
+dotnet_style_prefer_conditional_expression_over_return = true:silent
+###############################
+# Naming Conventions          #
+###############################
+# Style Definitions
+dotnet_naming_style.pascal_case_style.capitalization             = pascal_case
+# Use PascalCase for constant fields  
+dotnet_naming_rule.constant_fields_should_be_pascal_case.severity = suggestion
+dotnet_naming_rule.constant_fields_should_be_pascal_case.symbols  = constant_fields
+dotnet_naming_rule.constant_fields_should_be_pascal_case.style    = pascal_case_style
+dotnet_naming_symbols.constant_fields.applicable_kinds            = field
+dotnet_naming_symbols.constant_fields.applicable_accessibilities  = *
+dotnet_naming_symbols.constant_fields.required_modifiers          = const
+###############################
+# C# Coding Conventions       #
+###############################
+[*.cs]
+# var preferences
+csharp_style_var_for_built_in_types = true:silent
+csharp_style_var_when_type_is_apparent = true:silent
+csharp_style_var_elsewhere = true:silent
+# Expression-bodied members
+csharp_style_expression_bodied_methods = false:silent
+csharp_style_expression_bodied_constructors = false:silent
+csharp_style_expression_bodied_operators = false:silent
+csharp_style_expression_bodied_properties = true:silent
+csharp_style_expression_bodied_indexers = true:silent
+csharp_style_expression_bodied_accessors = true:silent
+# Pattern matching preferences
+csharp_style_pattern_matching_over_is_with_cast_check = true:suggestion
+csharp_style_pattern_matching_over_as_with_null_check = true:suggestion
+# Null-checking preferences
+csharp_style_throw_expression = true:suggestion
+csharp_style_conditional_delegate_call = true:suggestion
+# Modifier preferences
+csharp_preferred_modifier_order = public,private,protected,internal,static,extern,new,virtual,abstract,sealed,override,readonly,unsafe,volatile,async:suggestion
+# Expression-level preferences
+csharp_prefer_braces = true:silent
+csharp_style_deconstructed_variable_declaration = true:suggestion
+csharp_prefer_simple_default_expression = true:suggestion
+csharp_style_pattern_local_over_anonymous_function = true:suggestion
+csharp_style_inlined_variable_declaration = true:suggestion
+###############################
+# C# Formatting Rules         #
+###############################
+# New line preferences
+csharp_new_line_before_open_brace = all
+csharp_new_line_before_else = true
+csharp_new_line_before_catch = true
+csharp_new_line_before_finally = true
+csharp_new_line_before_members_in_object_initializers = true
+csharp_new_line_before_members_in_anonymous_types = true
+csharp_new_line_between_query_expression_clauses = true
+# Indentation preferences
+csharp_indent_case_contents = true
+csharp_indent_switch_labels = true
+csharp_indent_labels = flush_left
+# Space preferences
+csharp_space_after_cast = false
+csharp_space_after_keywords_in_control_flow_statements = true
+csharp_space_between_method_call_parameter_list_parentheses = false
+csharp_space_between_method_declaration_parameter_list_parentheses = false
+csharp_space_between_parentheses = false
+csharp_space_before_colon_in_inheritance_clause = true
+csharp_space_after_colon_in_inheritance_clause = true
+csharp_space_around_binary_operators = before_and_after
+csharp_space_between_method_declaration_empty_parameter_list_parentheses = false
+csharp_space_between_method_call_name_and_opening_parenthesis = false
+csharp_space_between_method_call_empty_parameter_list_parentheses = false
+# Wrapping preferences
+csharp_preserve_single_line_statements = true
+csharp_preserve_single_line_blocks = true
+###############################
+# VB Coding Conventions       #
+###############################
+[*.vb]
+# Modifier preferences
+visual_basic_preferred_modifier_order = Partial,Default,Private,Protected,Public,Friend,NotOverridable,Overridable,MustOverride,Overloads,Overrides,MustInherit,NotInheritable,Static,Shared,Shadows,ReadOnly,WriteOnly,Dim,Const,WithEvents,Widening,Narrowing,Custom,Async:suggestion

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@ TestResults
 .vs/
 
 *.user
+*.ncrunch*
+_NCrunch_*

--- a/Passbook.Generator.Tests/GeneratorTests.cs
+++ b/Passbook.Generator.Tests/GeneratorTests.cs
@@ -6,6 +6,7 @@ using System.IO;
 using System.Text;
 using Xunit;
 using Microsoft.CSharp;
+using TimeZoneConverter;
 
 namespace Passbook.Generator.Tests
 {
@@ -19,7 +20,7 @@ namespace Passbook.Generator.Tests
             request.Nfc = new Nfc("My NFC Message", "SKLSJLKJ");
 
             DateTime offset = new DateTime(2018, 01, 05, 12, 00, 0);
-            TimeZoneInfo zone = TimeZoneInfo.FindSystemTimeZoneById("Eastern Standard Time");
+            TimeZoneInfo zone = TZConvert.GetTimeZoneInfo("Eastern Standard Time");
             DateTimeOffset offsetConverted = new DateTimeOffset(offset, zone.GetUtcOffset(offset));
 
             request.RelevantDate = offsetConverted;
@@ -77,7 +78,7 @@ namespace Passbook.Generator.Tests
             request.Nfc = new Nfc("My NFC Message", "SKLSJLKJ");
 
             DateTime offset = new DateTime(2018, 01, 05, 12, 00, 0);
-            TimeZoneInfo zone = TimeZoneInfo.FindSystemTimeZoneById("Eastern Standard Time");
+            TimeZoneInfo zone = TZConvert.GetTimeZoneInfo("Eastern Standard Time");
             DateTimeOffset offsetConverted = new DateTimeOffset(offset, zone.GetUtcOffset(offset));
 
             request.RelevantDate = offsetConverted;

--- a/Passbook.Generator.Tests/GeneratorTests.cs
+++ b/Passbook.Generator.Tests/GeneratorTests.cs
@@ -1,17 +1,17 @@
-﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Newtonsoft.Json;
+﻿using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using Passbook.Generator.Fields;
 using System;
 using System.IO;
 using System.Text;
+using Xunit;
+using Microsoft.CSharp;
 
 namespace Passbook.Generator.Tests
 {
-    [TestClass]
     public class GeneratorTests
     {
-        [TestMethod]
+        [Fact]
         public void EnsurePassIsGeneratedCorrectly()
         {
             PassGeneratorRequest request = new PassGeneratorRequest();
@@ -48,28 +48,28 @@ namespace Passbook.Generator.Tests
 
                     dynamic json = JsonConvert.DeserializeObject(jsonString, settings);
 
-                    Assert.AreEqual("2018-01-01T00:00:00+00:00", (string)json["expirationDate"]);
-                    Assert.AreEqual("2018-01-05T12:00:00-05:00", (string)json["relevantDate"]);
+                    Assert.Equal("2018-01-01T00:00:00+00:00", (string)json["expirationDate"]);
+                    Assert.Equal("2018-01-05T12:00:00-05:00", (string)json["relevantDate"]);
 
                     var nfcPayload = (JToken)json["nfc"];
                     var nfcMessage = (string)nfcPayload["message"];
-                    Assert.AreEqual("My NFC Message", nfcMessage);
+                    Assert.Equal("My NFC Message", nfcMessage);
 
                     var genericKeys = json["generic"];
-                    Assert.AreEqual(1, genericKeys["auxiliaryFields"].Count);
+                    Assert.Equal(1, genericKeys["auxiliaryFields"].Count);
 
                     var auxField = genericKeys["auxiliaryFields"][0];
 
-                    Assert.AreEqual("aux-1", (string)auxField["key"]);
-                    Assert.AreEqual("Test", (string)auxField["value"]);
-                    Assert.AreEqual("Label", (string)auxField["label"]);
-                    Assert.AreEqual(1, (int)auxField["row"]);
+                    Assert.Equal("aux-1", (string)auxField["key"]);
+                    Assert.Equal("Test", (string)auxField["value"]);
+                    Assert.Equal("Label", (string)auxField["label"]);
+                    Assert.Equal(1, (int)auxField["row"]);
 
                 }
             }
         }
 
-        [TestMethod]
+        [Fact]
         public void EnsureFieldHasLocalTime()
         {
             PassGeneratorRequest request = new PassGeneratorRequest();
@@ -125,40 +125,40 @@ namespace Passbook.Generator.Tests
 
                     dynamic json = JsonConvert.DeserializeObject(jsonString, settings);
 
-                    Assert.AreEqual("2018-01-01T00:00:00+00:00", (string)json["expirationDate"]);
-                    Assert.AreEqual("2018-01-05T12:00:00-05:00", (string)json["relevantDate"]);
+                    Assert.Equal("2018-01-01T00:00:00+00:00", (string)json["expirationDate"]);
+                    Assert.Equal("2018-01-05T12:00:00-05:00", (string)json["relevantDate"]);
 
                     var nfcPayload = (JToken)json["nfc"];
                     var nfcMessage = (string)nfcPayload["message"];
-                    Assert.AreEqual("My NFC Message", nfcMessage);
+                    Assert.Equal("My NFC Message", nfcMessage);
 
                     var genericKeys = json["generic"];
-                    Assert.AreEqual(1, genericKeys["auxiliaryFields"].Count);
+                    Assert.Equal(3, genericKeys["auxiliaryFields"].Count);
 
                     var auxField = genericKeys["auxiliaryFields"][0];
 
-                    Assert.AreEqual("aux-1", (string)auxField["key"]);
-                    Assert.AreEqual("Test", (string)auxField["value"]);
-                    Assert.AreEqual("Label", (string)auxField["label"]);
-                    Assert.AreEqual(1, (int)auxField["row"]);
+                    Assert.Equal("aux-1", (string)auxField["key"]);
+                    Assert.Equal("Test", (string)auxField["value"]);
+                    Assert.Equal("Label", (string)auxField["label"]);
+                    Assert.Equal(1, (int)auxField["row"]);
 
                     var datetimeField = genericKeys["auxiliaryFields"][1];
-                    Assert.AreEqual("datetime-1", (string)datetimeField["key"]);
+                    Assert.Equal("datetime-1", (string)datetimeField["key"]);
                     string datetime1 = (string)datetimeField["value"];
                     string expected1start = string.Format("{0:yyyy-MM-ddTHH:mm}", local);
 
-                    Assert.IsTrue(datetime1.StartsWith(expected1start));
-                    Assert.IsFalse(datetime1.Contains("Z"));
-                    Assert.AreEqual("Label", (string)datetimeField["label"]);
+                    Assert.StartsWith(expected1start, datetime1);
+                    Assert.DoesNotContain("Z", datetime1);
+                    Assert.Equal("Label", (string)datetimeField["label"]);
 
 
                     var utcdatetimeField = genericKeys["auxiliaryFields"][2];
-                    Assert.AreEqual("datetime-1", (string)utcdatetimeField["key"]);
+                    Assert.Equal("datetime-2", (string)utcdatetimeField["key"]);
                     string datetime2 = (string)utcdatetimeField["value"];
-                    string expected2 = string.Format("{0:yyyy-MM-ddTHH:mm}Z", utc);
+                    string expected2 = string.Format("{0:yyyy-MM-ddTHH:mm:ss}Z", utc);
 
-                    Assert.AreEqual(expected2, datetime2);
-                    Assert.AreEqual("Label", (string)utcdatetimeField["label"]);
+                    Assert.Equal(expected2, datetime2);
+                    Assert.Equal("Label", (string)utcdatetimeField["label"]);
 
                 }
             }

--- a/Passbook.Generator.Tests/Passbook.Generator.Tests.csproj
+++ b/Passbook.Generator.Tests/Passbook.Generator.Tests.csproj
@@ -1,77 +1,28 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\packages\MSTest.TestAdapter.1.3.2\build\net45\MSTest.TestAdapter.props" Condition="Exists('..\packages\MSTest.TestAdapter.1.3.2\build\net45\MSTest.TestAdapter.props')" />
-  <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{9366CDD5-5B37-4C40-9661-47B205C6D01D}</ProjectGuid>
-    <OutputType>Library</OutputType>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>Passbook.Generator.Tests</RootNamespace>
-    <AssemblyName>Passbook.Generator.Tests</AssemblyName>
-    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
-    <FileAlignment>512</FileAlignment>
-    <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
-    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">15.0</VisualStudioVersion>
-    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
-    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\$(VisualStudioVersion)\UITestExtensionPackages</ReferencePath>
-    <IsCodedUITest>False</IsCodedUITest>
-    <TestProjectType>UnitTest</TestProjectType>
-    <NuGetPackageImportStamp>
-    </NuGetPackageImportStamp>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-  </PropertyGroup>
-  <ItemGroup>
-    <Reference Include="Microsoft.CSharp" />
-    <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\MSTest.TestFramework.1.3.2\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\MSTest.TestFramework.1.3.2\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions.dll</HintPath>
-    </Reference>
-    <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.12.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
-    </Reference>
-    <Reference Include="System" />
-    <Reference Include="System.Core" />
-  </ItemGroup>
-  <ItemGroup>
-    <Compile Include="GeneratorTests.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="packages.config" />
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\Passbook.Generator\Passbook.Generator.csproj">
-      <Project>{3723ca11-bb28-4ce6-b70c-2631df1f14a1}</Project>
-      <Name>Passbook.Generator</Name>
-    </ProjectReference>
-  </ItemGroup>
-  <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
-    <PropertyGroup>
-      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
-    </PropertyGroup>
-    <Error Condition="!Exists('..\packages\MSTest.TestAdapter.1.3.2\build\net45\MSTest.TestAdapter.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\MSTest.TestAdapter.1.3.2\build\net45\MSTest.TestAdapter.props'))" />
-    <Error Condition="!Exists('..\packages\MSTest.TestAdapter.1.3.2\build\net45\MSTest.TestAdapter.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\MSTest.TestAdapter.1.3.2\build\net45\MSTest.TestAdapter.targets'))" />
-  </Target>
-  <Import Project="..\packages\MSTest.TestAdapter.1.3.2\build\net45\MSTest.TestAdapter.targets" Condition="Exists('..\packages\MSTest.TestAdapter.1.3.2\build\net45\MSTest.TestAdapter.targets')" />
+﻿<Project Sdk="Microsoft.NET.Sdk">
+	<PropertyGroup>
+		<TargetFrameworks>net48;netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
+		<GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+	</PropertyGroup>
+	<ItemGroup>
+		<PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
+		<PackageReference Include="xunit" Version="2.4.1" />
+		<PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+			<PrivateAssets>all</PrivateAssets>
+		</PackageReference>
+		<PackageReference Include="xunit.runner.console" Version="2.4.1">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
+	</ItemGroup>
+	<ItemGroup>
+		<ProjectReference Include="..\Passbook.Generator\Passbook.Generator.csproj" />
+	</ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="coverlet.collector" Version="3.1.0">
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+			<PrivateAssets>all</PrivateAssets>
+		</PackageReference>
+	</ItemGroup>
 </Project>

--- a/Passbook.Generator.Tests/Passbook.Generator.Tests.csproj
+++ b/Passbook.Generator.Tests/Passbook.Generator.Tests.csproj
@@ -6,6 +6,7 @@
 	<ItemGroup>
 		<PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
+		<PackageReference Include="TimeZoneConverter" Version="3.5.0" />
 		<PackageReference Include="xunit" Version="2.4.1" />
 		<PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Passbook.Generator.Tests/packages.config
+++ b/Passbook.Generator.Tests/packages.config
@@ -1,6 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="MSTest.TestAdapter" version="1.3.2" targetFramework="net461" />
-  <package id="MSTest.TestFramework" version="1.3.2" targetFramework="net461" />
-  <package id="Newtonsoft.Json" version="12.0.2" targetFramework="net461" />
-</packages>


### PR DESCRIPTION
This PR replaces the Visual Studio / MSTest runner used in the Passbook.Generator.Tests project with xUnit, and sets up the test project so that you can run tests on Linux/macOS using `dotnet test` as well as using the Visual Studio test runner.

The TimeZoneConvert package is required to get consistent cross-platform timezone behaviour on .NET versions below 6.0.