### PR TITLE
Replace MSTest with xUnit and add support for running tests on .NET Core 3.1/5/6 on Linux/macOS

### DIFF
--- a/Passbook.Generator.Tests/GeneratorTests.cs
+++ b/Passbook.Generator.Tests/GeneratorTests.cs
@@ -1,17 +1,18 @@
-﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Newtonsoft.Json;
+﻿using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using Passbook.Generator.Fields;
 using System;
 using System.IO;
 using System.Text;
+using Xunit;
+using Microsoft.CSharp;
+using TimeZoneConverter;
 
 namespace Passbook.Generator.Tests
 {
-    [TestClass]
     public class GeneratorTests
     {
-        [TestMethod]
+        [Fact]
         public void EnsurePassIsGeneratedCorrectly()
         {
             PassGeneratorRequest request = new PassGeneratorRequest();
@@ -19,7 +20,7 @@ namespace Passbook.Generator.Tests
             request.Nfc = new Nfc("My NFC Message", "SKLSJLKJ");
 
             DateTime offset = new DateTime(2018, 01, 05, 12, 00, 0);
-            TimeZoneInfo zone = TimeZoneInfo.FindSystemTimeZoneById("Eastern Standard Time");
+            TimeZoneInfo zone = TZConvert.GetTimeZoneInfo("Eastern Standard Time");
             DateTimeOffset offsetConverted = new DateTimeOffset(offset, zone.GetUtcOffset(offset));
 
             request.RelevantDate = offsetConverted;
@@ -48,28 +49,28 @@ namespace Passbook.Generator.Tests
 
                     dynamic json = JsonConvert.DeserializeObject(jsonString, settings);
 
-                    Assert.AreEqual("2018-01-01T00:00:00+00:00", (string)json["expirationDate"]);
-                    Assert.AreEqual("2018-01-05T12:00:00-05:00", (string)json["relevantDate"]);
+                    Assert.Equal("2018-01-01T00:00:00+00:00", (string)json["expirationDate"]);
+                    Assert.Equal("2018-01-05T12:00:00-05:00", (string)json["relevantDate"]);
 
                     var nfcPayload = (JToken)json["nfc"];
                     var nfcMessage = (string)nfcPayload["message"];
-                    Assert.AreEqual("My NFC Message", nfcMessage);
+                    Assert.Equal("My NFC Message", nfcMessage);
 
                     var genericKeys = json["generic"];
-                    Assert.AreEqual(1, genericKeys["auxiliaryFields"].Count);
+                    Assert.Equal(1, genericKeys["auxiliaryFields"].Count);
 
                     var auxField = genericKeys["auxiliaryFields"][0];
 
-                    Assert.AreEqual("aux-1", (string)auxField["key"]);
-                    Assert.AreEqual("Test", (string)auxField["value"]);
-                    Assert.AreEqual("Label", (string)auxField["label"]);
-                    Assert.AreEqual(1, (int)auxField["row"]);
+                    Assert.Equal("aux-1", (string)auxField["key"]);
+                    Assert.Equal("Test", (string)auxField["value"]);
+                    Assert.Equal("Label", (string)auxField["label"]);
+                    Assert.Equal(1, (int)auxField["row"]);
 
                 }
             }
         }
 
-        [TestMethod]
+        [Fact]
         public void EnsureFieldHasLocalTime()
         {
             PassGeneratorRequest request = new PassGeneratorRequest();
@@ -77,7 +78,7 @@ namespace Passbook.Generator.Tests
             request.Nfc = new Nfc("My NFC Message", "SKLSJLKJ");
 
             DateTime offset = new DateTime(2018, 01, 05, 12, 00, 0);
-            TimeZoneInfo zone = TimeZoneInfo.FindSystemTimeZoneById("Eastern Standard Time");
+            TimeZoneInfo zone = TZConvert.GetTimeZoneInfo("Eastern Standard Time");
             DateTimeOffset offsetConverted = new DateTimeOffset(offset, zone.GetUtcOffset(offset));
 
             request.RelevantDate = offsetConverted;
@@ -125,40 +126,40 @@ namespace Passbook.Generator.Tests
 
                     dynamic json = JsonConvert.DeserializeObject(jsonString, settings);
 
-                    Assert.AreEqual("2018-01-01T00:00:00+00:00", (string)json["expirationDate"]);
-                    Assert.AreEqual("2018-01-05T12:00:00-05:00", (string)json["relevantDate"]);
+                    Assert.Equal("2018-01-01T00:00:00+00:00", (string)json["expirationDate"]);
+                    Assert.Equal("2018-01-05T12:00:00-05:00", (string)json["relevantDate"]);
 
                     var nfcPayload = (JToken)json["nfc"];
                     var nfcMessage = (string)nfcPayload["message"];
-                    Assert.AreEqual("My NFC Message", nfcMessage);
+                    Assert.Equal("My NFC Message", nfcMessage);
 
                     var genericKeys = json["generic"];
-                    Assert.AreEqual(1, genericKeys["auxiliaryFields"].Count);
+                    Assert.Equal(3, genericKeys["auxiliaryFields"].Count);
 
                     var auxField = genericKeys["auxiliaryFields"][0];
 
-                    Assert.AreEqual("aux-1", (string)auxField["key"]);
-                    Assert.AreEqual("Test", (string)auxField["value"]);
-                    Assert.AreEqual("Label", (string)auxField["label"]);
-                    Assert.AreEqual(1, (int)auxField["row"]);
+                    Assert.Equal("aux-1", (string)auxField["key"]);
+                    Assert.Equal("Test", (string)auxField["value"]);
+                    Assert.Equal("Label", (string)auxField["label"]);
+                    Assert.Equal(1, (int)auxField["row"]);
 
                     var datetimeField = genericKeys["auxiliaryFields"][1];
-                    Assert.AreEqual("datetime-1", (string)datetimeField["key"]);
+                    Assert.Equal("datetime-1", (string)datetimeField["key"]);
                     string datetime1 = (string)datetimeField["value"];
                     string expected1start = string.Format("{0:yyyy-MM-ddTHH:mm}", local);
 
-                    Assert.IsTrue(datetime1.StartsWith(expected1start));
-                    Assert.IsFalse(datetime1.Contains("Z"));
-                    Assert.AreEqual("Label", (string)datetimeField["label"]);
+                    Assert.StartsWith(expected1start, datetime1);
+                    Assert.DoesNotContain("Z", datetime1);
+                    Assert.Equal("Label", (string)datetimeField["label"]);
 
 
                     var utcdatetimeField = genericKeys["auxiliaryFields"][2];
-                    Assert.AreEqual("datetime-1", (string)utcdatetimeField["key"]);
+                    Assert.Equal("datetime-2", (string)utcdatetimeField["key"]);
                     string datetime2 = (string)utcdatetimeField["value"];
-                    string expected2 = string.Format("{0:yyyy-MM-ddTHH:mm}Z", utc);
+                    string expected2 = string.Format("{0:yyyy-MM-ddTHH:mm:ss}Z", utc);
 
-                    Assert.AreEqual(expected2, datetime2);
-                    Assert.AreEqual("Label", (string)utcdatetimeField["label"]);
+                    Assert.Equal(expected2, datetime2);
+                    Assert.Equal("Label", (string)utcdatetimeField["label"]);
 
                 }
             }

--- a/Passbook.Generator.Tests/Passbook.Generator.Tests.csproj
+++ b/Passbook.Generator.Tests/Passbook.Generator.Tests.csproj
@@ -1,77 +1,29 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\packages\MSTest.TestAdapter.1.3.2\build\net45\MSTest.TestAdapter.props" Condition="Exists('..\packages\MSTest.TestAdapter.1.3.2\build\net45\MSTest.TestAdapter.props')" />
-  <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{9366CDD5-5B37-4C40-9661-47B205C6D01D}</ProjectGuid>
-    <OutputType>Library</OutputType>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>Passbook.Generator.Tests</RootNamespace>
-    <AssemblyName>Passbook.Generator.Tests</AssemblyName>
-    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
-    <FileAlignment>512</FileAlignment>
-    <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
-    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">15.0</VisualStudioVersion>
-    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
-    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\$(VisualStudioVersion)\UITestExtensionPackages</ReferencePath>
-    <IsCodedUITest>False</IsCodedUITest>
-    <TestProjectType>UnitTest</TestProjectType>
-    <NuGetPackageImportStamp>
-    </NuGetPackageImportStamp>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-  </PropertyGroup>
-  <ItemGroup>
-    <Reference Include="Microsoft.CSharp" />
-    <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\MSTest.TestFramework.1.3.2\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\MSTest.TestFramework.1.3.2\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions.dll</HintPath>
-    </Reference>
-    <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.12.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
-    </Reference>
-    <Reference Include="System" />
-    <Reference Include="System.Core" />
-  </ItemGroup>
-  <ItemGroup>
-    <Compile Include="GeneratorTests.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="packages.config" />
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\Passbook.Generator\Passbook.Generator.csproj">
-      <Project>{3723ca11-bb28-4ce6-b70c-2631df1f14a1}</Project>
-      <Name>Passbook.Generator</Name>
-    </ProjectReference>
-  </ItemGroup>
-  <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
-    <PropertyGroup>
-      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
-    </PropertyGroup>
-    <Error Condition="!Exists('..\packages\MSTest.TestAdapter.1.3.2\build\net45\MSTest.TestAdapter.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\MSTest.TestAdapter.1.3.2\build\net45\MSTest.TestAdapter.props'))" />
-    <Error Condition="!Exists('..\packages\MSTest.TestAdapter.1.3.2\build\net45\MSTest.TestAdapter.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\MSTest.TestAdapter.1.3.2\build\net45\MSTest.TestAdapter.targets'))" />
-  </Target>
-  <Import Project="..\packages\MSTest.TestAdapter.1.3.2\build\net45\MSTest.TestAdapter.targets" Condition="Exists('..\packages\MSTest.TestAdapter.1.3.2\build\net45\MSTest.TestAdapter.targets')" />
+﻿<Project Sdk="Microsoft.NET.Sdk">
+	<PropertyGroup>
+		<TargetFrameworks>net48;netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
+		<GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+	</PropertyGroup>
+	<ItemGroup>
+		<PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
+		<PackageReference Include="TimeZoneConverter" Version="3.5.0" />
+		<PackageReference Include="xunit" Version="2.4.1" />
+		<PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+			<PrivateAssets>all</PrivateAssets>
+		</PackageReference>
+		<PackageReference Include="xunit.runner.console" Version="2.4.1">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
+	</ItemGroup>
+	<ItemGroup>
+		<ProjectReference Include="..\Passbook.Generator\Passbook.Generator.csproj" />
+	</ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="coverlet.collector" Version="3.1.0">
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+			<PrivateAssets>all</PrivateAssets>
+		</PackageReference>
+	</ItemGroup>
 </Project>

--- a/Passbook.Generator.Tests/packages.config
+++ b/Passbook.Generator.Tests/packages.config
@@ -1,6 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="MSTest.TestAdapter" version="1.3.2" targetFramework="net461" />
-  <package id="MSTest.TestFramework" version="1.3.2" targetFramework="net461" />
-  <package id="Newtonsoft.Json" version="12.0.2" targetFramework="net461" />
-</packages>


### PR DESCRIPTION
* Replace MSTest fixtures with xUnit fixtures
* Add the TimeZoneConvert package to provide cross-platform timezone consistency on .NET Core 3.1 and .NET 5 (.NET 6 has this built-in)
* Add .editorconfig 
* Replace Passbook.Generator.Tests.csproj with .NET core/5/6 style CSPROJ file including package dependencies.