### PR TITLE
Use correct semantic tag for silenceRequested

### DIFF
--- a/Passbook.Generator/Tags/silenceRequested.cs
+++ b/Passbook.Generator/Tags/silenceRequested.cs
@@ -2,7 +2,7 @@
 {
     public class SilenceRequested : SemanticTagBaseValue
     {
-        public SilenceRequested(bool value) : base("sportName", value)
+        public SilenceRequested(bool value) : base("silenceRequested", value)
         {
             // NO OP
         }


### PR DESCRIPTION
Motivation
----------
The wrong tag is currently used, which prevents passes from being added to the wallet.

Modifications
-------------
Use the correct key `silenceRequested`.