### PR TITLE
Migrate to .Net8

### DIFF
--- a/Passbook.Generator.Tests/Passbook.Generator.Tests.csproj
+++ b/Passbook.Generator.Tests/Passbook.Generator.Tests.csproj
@@ -1,29 +1,19 @@
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFrameworks>net48;netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
-		<GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+		<TargetFrameworks>net8.0</TargetFrameworks>
+		<ImplicitUsings>enable</ImplicitUsings>
+		<IsTestProject>true</IsTestProject>
+		<Nullable>enable</Nullable>
 	</PropertyGroup>
 	<ItemGroup>
-		<PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
-		<PackageReference Include="TimeZoneConverter" Version="3.5.0" />
-		<PackageReference Include="xunit" Version="2.4.1" />
-		<PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
-			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-			<PrivateAssets>all</PrivateAssets>
-		</PackageReference>
-		<PackageReference Include="xunit.runner.console" Version="2.4.1">
-			<PrivateAssets>all</PrivateAssets>
-			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-		</PackageReference>
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+		<PackageReference Include="TimeZoneConverter" Version="6.1.0" />
+		<PackageReference Include="xunit" Version="2.9.2" />
+		<PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+		<PackageReference Include="xunit.runner.console" Version="2.9.2" />
+		<PackageReference Include="coverlet.collector" Version="6.0.2" />
 	</ItemGroup>
 	<ItemGroup>
 		<ProjectReference Include="..\Passbook.Generator\Passbook.Generator.csproj" />
-	</ItemGroup>
-	<ItemGroup>
-		<PackageReference Include="coverlet.collector" Version="3.1.0">
-			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-			<PrivateAssets>all</PrivateAssets>
-		</PackageReference>
 	</ItemGroup>
 </Project>

--- a/Passbook.Generator.Tests/SemanticTagsTests.cs
+++ b/Passbook.Generator.Tests/SemanticTagsTests.cs
@@ -1,46 +1,51 @@
-﻿using Newtonsoft.Json;
-using Passbook.Generator.Tags;
+﻿using Passbook.Generator.Tags;
 using System.IO;
 using System.Text;
+using System.Text.Json;
 using Xunit;
 
-namespace Passbook.Generator.Tests
+namespace Passbook.Generator.Tests;
+
+public class SemanticTagsTests
 {
-    public class SemanticTagsTests
+    [Fact]
+    public void EnsureSemanticFieldsIsGeneratedCorrectly()
     {
-        [Fact]
-        public void EnsureSemanticFieldsIsGeneratedCorrectly()
+        PassGeneratorRequest request = new PassGeneratorRequest();
+        request.SemanticTags.Add(new AirlineCode("EX"));
+        request.SemanticTags.Add(new Balance("1000", "GBP"));
+
+        using var ms = new MemoryStream();
+        var options = new JsonWriterOptions { Indented = true };
+        using (var writer = new Utf8JsonWriter(ms, options))
+        
+        request.Write(writer);
+
+        string jsonString = Encoding.UTF8.GetString(ms.ToArray());
+
+        using var doc = JsonDocument.Parse(jsonString);
+        var root = doc.RootElement;
+
+        if (!root.TryGetProperty("semantics", out JsonElement semantics))
         {
-            PassGeneratorRequest request = new PassGeneratorRequest();
-            request.SemanticTags.Add(new AirlineCode("EX"));
-            request.SemanticTags.Add(new Balance("1000", "GBP"));
-
-            using (MemoryStream ms = new MemoryStream())
-            {
-                using (StreamWriter sr = new StreamWriter(ms))
-                {
-                    using (JsonWriter writer = new JsonTextWriter(sr))
-                    {
-                        writer.Formatting = Formatting.Indented;
-                        request.Write(writer);
-                    }
-
-                    string jsonString = Encoding.UTF8.GetString(ms.ToArray());
-
-                    var settings = new JsonSerializerSettings { DateParseHandling = DateParseHandling.None };
-
-                    dynamic json = JsonConvert.DeserializeObject(jsonString, settings);
-
-                    var semantics = json["semantics"];
-
-                    var airlineCode = semantics.airlineCode;
-                    Assert.Equal("EX", (string)airlineCode);
-
-                    var balance = semantics.balance;
-                    Assert.Equal("1000", (string)balance.amount);
-                    Assert.Equal("GBP", (string)balance.currencyCode);
-                }
-            }
+            Assert.Fail("semantics not found");
         }
+
+        if (!semantics.TryGetProperty("airlineCode", out JsonElement airlineCode))
+        {
+            Assert.Fail("airlineCode not found");
+        }
+        Assert.Equal("EX", airlineCode.GetString());
+
+        if (!semantics.TryGetProperty("balance", out JsonElement balance))
+        {
+            Assert.Fail("balance not found");
+        }
+
+        if (!balance.TryGetProperty("amount", out JsonElement amount))
+        {
+            Assert.Fail("amount not found");
+        }
+        Assert.Equal("1000", amount.GetString());
     }
 }

--- a/Passbook.Generator/Exceptions/DuplicateFieldKeyException.cs
+++ b/Passbook.Generator/Exceptions/DuplicateFieldKeyException.cs
@@ -1,11 +1,7 @@
 ﻿using System;
 
-namespace Passbook.Generator.Exceptions
+namespace Passbook.Generator.Exceptions;
+
+public class DuplicateFieldKeyException(string key) : Exception($"A field with the key `{key}` is already present")
 {
-    public class DuplicateFieldKeyException : Exception
-    {
-        public DuplicateFieldKeyException(string key) :
-            base($"A field with the key `{key}` is already present")
-        { }
-    }
 }

--- a/Passbook.Generator/Exceptions/ManifestSigningException.cs
+++ b/Passbook.Generator/Exceptions/ManifestSigningException.cs
@@ -1,16 +1,11 @@
 ﻿using System;
 
-namespace Passbook.Generator.Exceptions
+namespace Passbook.Generator.Exceptions;
+
+[Serializable]
+public class ManifestSigningException : Exception
 {
-    [Serializable]
-    public class ManifestSigningException : Exception
-    {
-        public ManifestSigningException() { }
-        public ManifestSigningException(string message) : base(message) { }
-        public ManifestSigningException(string message, Exception inner) : base(message, inner) { }
-        protected ManifestSigningException(
-          System.Runtime.Serialization.SerializationInfo info,
-          System.Runtime.Serialization.StreamingContext context)
-            : base(info, context) { }
-    }
+    public ManifestSigningException() { }
+    public ManifestSigningException(string message) : base(message) { }
+    public ManifestSigningException(string message, Exception inner) : base(message, inner) { }
 }

--- a/Passbook.Generator/Exceptions/RequiredFieldValueMissingException.cs
+++ b/Passbook.Generator/Exceptions/RequiredFieldValueMissingException.cs
@@ -1,12 +1,8 @@
 ﻿using System;
 
-namespace Passbook.Generator.Exceptions
+namespace Passbook.Generator.Exceptions;
+
+[Serializable]
+public class RequiredFieldValueMissingException(string fieldName) : Exception("Missing value for field [key: '" + fieldName + "']. Every field must have a value specified in the template or the individual pass.")
 {
-    [Serializable]
-    public class RequiredFieldValueMissingException : Exception
-    {
-        public RequiredFieldValueMissingException(string fieldName) :
-            base("Missing value for field [key: '" + fieldName + "']. Every field must have a value specified in the template or the individual pass.")
-        { }
-    }
 }

--- a/Passbook.Generator/Extensions/DataDetectorTypeExtensions.cs
+++ b/Passbook.Generator/Extensions/DataDetectorTypeExtensions.cs
@@ -1,26 +1,20 @@
 ﻿using Passbook.Generator.Fields;
 
-namespace Passbook.Generator
+namespace Passbook.Generator;
+
+public static class DataDetectorTypeExtensions
 {
-    public static class DataDetectorTypeExtensions
+    // Dotfuscated friendly enum name conversion
+    // http://stackoverflow.com/questions/483794/convert-enum-to-string
+    public static string ToSafeString(this DataDetectorTypes dataDetectorType)
     {
-        // Dotfucated friendly enum name conversion
-        // http://stackoverflow.com/questions/483794/convert-enum-to-string
-        public static string ToSafeString(this DataDetectorTypes dataDetectorType)
+        return dataDetectorType switch
         {
-            switch (dataDetectorType)
-            {
-                case DataDetectorTypes.PKDataDetectorTypeAddress:
-                    return "PKDataDetectorTypeAddress";
-                case DataDetectorTypes.PKDataDetectorTypeCalendarEvent:
-                    return "PKDataDetectorTypeCalendarEvent";
-                case DataDetectorTypes.PKDataDetectorTypeLink:
-                    return "PKDataDetectorTypeLink";
-                case DataDetectorTypes.PKDataDetectorTypePhoneNumber:
-                    return "PKDataDetectorTypePhoneNumber";
-                default:
-                    return "";
-            }
-        }
+            DataDetectorTypes.PKDataDetectorTypeAddress => "PKDataDetectorTypeAddress",
+            DataDetectorTypes.PKDataDetectorTypeCalendarEvent => "PKDataDetectorTypeCalendarEvent",
+            DataDetectorTypes.PKDataDetectorTypeLink => "PKDataDetectorTypeLink",
+            DataDetectorTypes.PKDataDetectorTypePhoneNumber => "PKDataDetectorTypePhoneNumber",
+            _ => "",
+        };
     }
 }

--- a/Passbook.Generator/Fields/BarCode.cs
+++ b/Passbook.Generator/Fields/BarCode.cs
@@ -1,61 +1,60 @@
-﻿using Newtonsoft.Json;
+﻿using System.Text.Json;
 
-namespace Passbook.Generator.Fields
+namespace Passbook.Generator.Fields;
+
+public class Barcode
 {
-    public class Barcode
+    public Barcode(BarcodeType type, string message, string encoding)
     {
-        public Barcode(BarcodeType type, string message, string encoding)
+        Type = type;
+        Message = message;
+        Encoding = encoding;
+    }
+
+    public Barcode(BarcodeType type, string message, string encoding, string alternateText)
+    {
+        Type = type;
+        Message = message;
+        Encoding = encoding;
+        AlternateText = alternateText;
+    }
+
+    /// <summary>
+    /// Required. Barcode format
+    /// </summary>
+    public BarcodeType Type { get; set; }
+
+    /// <summary>
+    /// Required. Message or payload to be displayed as a barcode.
+    /// </summary>
+    public string Message { get; set; }
+
+    /// <summary>
+    /// Required. Text encoding that is used to convert the message from the string representation to a data representation to render the barcode. The value is typically iso-8859-1, but you may use another encoding that is supported by your barcode scanning infrastructure.
+    /// </summary>
+    public string Encoding { get; set; }
+
+    /// <summary>
+    /// Optional. Text displayed near the barcode. For example, a human-readable version of the barcode data in case the barcode doesn’t scan.
+    /// </summary>
+    public string AlternateText { get; set; }
+
+    public void Write(Utf8JsonWriter writer)
+    {
+        writer.WriteStartObject();
+        writer.WritePropertyName("format");
+        writer.WriteStringValue(Type.ToString());
+        writer.WritePropertyName("message");
+        writer.WriteStringValue(Message);
+        writer.WritePropertyName("messageEncoding");
+        writer.WriteStringValue(Encoding);
+
+        if (!string.IsNullOrEmpty(AlternateText))
         {
-            Type = type;
-            Message = message;
-            Encoding = encoding;
+            writer.WritePropertyName("altText");
+            writer.WriteStringValue(AlternateText);
         }
 
-        public Barcode(BarcodeType type, string message, string encoding, string alternateText)
-        {
-            Type = type;
-            Message = message;
-            Encoding = encoding;
-            AlternateText = alternateText;
-        }
-
-        /// <summary>
-        /// Required. Barcode format
-        /// </summary>
-        public BarcodeType Type { get; set; }
-
-        /// <summary>
-        /// Required. Message or payload to be displayed as a barcode.
-        /// </summary>
-        public string Message { get; set; }
-
-        /// <summary>
-        /// Required. Text encoding that is used to convert the message from the string representation to a data representation to render the barcode. The value is typically iso-8859-1, but you may use another encoding that is supported by your barcode scanning infrastructure.
-        /// </summary>
-        public string Encoding { get; set; }
-
-        /// <summary>
-        /// Optional. Text displayed near the barcode. For example, a human-readable version of the barcode data in case the barcode doesn’t scan.
-        /// </summary>
-        public string AlternateText { get; set; }
-
-        public void Write(JsonWriter writer)
-        {
-            writer.WriteStartObject();
-            writer.WritePropertyName("format");
-            writer.WriteValue(Type.ToString());
-            writer.WritePropertyName("message");
-            writer.WriteValue(Message);
-            writer.WritePropertyName("messageEncoding");
-            writer.WriteValue(Encoding);
-
-            if (!string.IsNullOrEmpty(AlternateText))
-            {
-                writer.WritePropertyName("altText");
-                writer.WriteValue(AlternateText);
-            }
-
-            writer.WriteEndObject();
-        }
+        writer.WriteEndObject();
     }
 }

--- a/Passbook.Generator/Fields/DateField.cs
+++ b/Passbook.Generator/Fields/DateField.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Globalization;
+using System.Text.Json;
 
 namespace Passbook.Generator.Fields
 {
@@ -12,16 +13,16 @@ namespace Passbook.Generator.Fields
         public DateField(string key, string label, FieldDateTimeStyle dateStyle, FieldDateTimeStyle timeStyle)
             : base(key, label)
         {
-            this.DateStyle = dateStyle;
-            this.TimeStyle = timeStyle;
+            DateStyle = dateStyle;
+            TimeStyle = timeStyle;
         }
 
         public DateField(string key, string label, FieldDateTimeStyle dateStyle, FieldDateTimeStyle timeStyle, DateTime value)
             : base(key, label)
         {
-            this.Value = value;
-            this.DateStyle = dateStyle;
-            this.TimeStyle = timeStyle;
+            Value = value;
+            DateStyle = dateStyle;
+            TimeStyle = timeStyle;
         }
 
         public DateTime Value { get; set; }
@@ -46,44 +47,44 @@ namespace Passbook.Generator.Fields
         /// </summary>
         public bool? IgnoresTimeZone { get; set; }
 
-        protected override void WriteKeys(Newtonsoft.Json.JsonWriter writer)
+        protected override void WriteKeys(Utf8JsonWriter writer)
         {
             if (DateStyle != FieldDateTimeStyle.Unspecified)
             {
                 writer.WritePropertyName("dateStyle");
-                writer.WriteValue(DateStyle.ToString());
+                writer.WriteStringValue(DateStyle.ToString());
             }
 
             if (TimeStyle != FieldDateTimeStyle.Unspecified)
             {
                 writer.WritePropertyName("timeStyle");
-                writer.WriteValue(TimeStyle.ToString());
+                writer.WriteStringValue(TimeStyle.ToString());
             }
 
             if (IsRelative.HasValue)
             {
                 writer.WritePropertyName("isRelative");
-                writer.WriteValue(IsRelative.Value);
+                writer.WriteBooleanValue(IsRelative.Value);
             }
 
             if (IgnoresTimeZone.HasValue)
             {
                 writer.WritePropertyName("ignoresTimeZone");
-                writer.WriteValue(IgnoresTimeZone.Value);
+                writer.WriteBooleanValue(IgnoresTimeZone.Value);
             }
         }
 
-        protected override void WriteValue(Newtonsoft.Json.JsonWriter writer)
+        protected override void WriteValue(Utf8JsonWriter writer)
         {
-            if (this.Value.Kind == DateTimeKind.Utc ||
-                this.Value.Kind == DateTimeKind.Unspecified)
+            if (Value.Kind == DateTimeKind.Utc ||
+                Value.Kind == DateTimeKind.Unspecified)
             {
-                writer.WriteValue(Value.ToString("yyyy-MM-ddTHH:mm:ssZ"));
+                writer.WriteStringValue(Value.ToString("yyyy-MM-ddTHH:mm:ssZ"));
             }
             else
             {
-                var localDate = new DateTime(this.Value.Year, this.Value.Month, this.Value.Day, this.Value.Hour, this.Value.Minute, this.Value.Second, this.Value.Kind);
-                var utcDate = new DateTime(this.Value.Year, this.Value.Month, this.Value.Day, this.Value.Hour, this.Value.Minute, this.Value.Second, this.Value.Kind);
+                var localDate = new DateTime(Value.Year, Value.Month, Value.Day, Value.Hour, Value.Minute, Value.Second, Value.Kind);
+                var utcDate = new DateTime(Value.Year, Value.Month, Value.Day, Value.Hour, Value.Minute, Value.Second, Value.Kind);
                 var diff = utcDate - localDate.ToUniversalTime();
 
                 string outputText = localDate.ToString("yyyy-MM-ddTHH:mm:ss", CultureInfo.InvariantCulture);
@@ -96,13 +97,13 @@ namespace Passbook.Generator.Fields
                     outputText = string.Format("{0}+{1:00}:{2:00}", outputText, Math.Abs(diff.Hours), diff.Minutes);
                 }
                 
-                writer.WriteValue(outputText);
+                writer.WriteStringValue(outputText);
             }
         }
 
         public override void SetValue(object value)
         {
-            this.Value = (DateTime)value;
+            Value = (DateTime)value;
         }
 
         public override bool HasValue

--- a/Passbook.Generator/Fields/Field.cs
+++ b/Passbook.Generator/Fields/Field.cs
@@ -1,6 +1,6 @@
-﻿using Newtonsoft.Json;
-using Passbook.Generator.Exceptions;
+﻿using Passbook.Generator.Exceptions;
 using System;
+using System.Text.Json;
 
 namespace Passbook.Generator.Fields
 {
@@ -8,21 +8,21 @@ namespace Passbook.Generator.Fields
     {
         public Field()
         {
-            this.DataDetectorTypes = DataDetectorTypes.PKDataDetectorAll;
+            DataDetectorTypes = DataDetectorTypes.PKDataDetectorAll;
         }
 
         public Field(string key, string label)
             : this()
         {
-            this.Key = key;
-            this.Label = label;
+            Key = key;
+            Label = label;
         }
 
         public Field(string key, string label, string changeMessage, FieldTextAlignment textAligment)
             : this(key, label)
         {
-            this.ChangeMessage = changeMessage;
-            this.TextAlignment = textAligment;
+            ChangeMessage = changeMessage;
+            TextAlignment = textAligment;
         }
 
         /// <summary>
@@ -95,43 +95,43 @@ namespace Passbook.Generator.Fields
         /// </summary>
         public int? Row { get; set; }
 
-        public void Write(JsonWriter writer)
+        public void Write(Utf8JsonWriter writer)
         {
             Validate();
 
             writer.WriteStartObject();
 
             writer.WritePropertyName("key");
-            writer.WriteValue(Key);
+            writer.WriteStringValue(Key);
 
             if (!string.IsNullOrEmpty(ChangeMessage))
             {
                 writer.WritePropertyName("changeMessage");
-                writer.WriteValue(ChangeMessage);
+                writer.WriteStringValue(ChangeMessage);
             }
 
             if (!string.IsNullOrEmpty(Label))
             {
                 writer.WritePropertyName("label");
-                writer.WriteValue(Label);
+                writer.WriteStringValue(Label);
             }
 
             if (TextAlignment != FieldTextAlignment.Unspecified)
             {
                 writer.WritePropertyName("textAlignment");
-                writer.WriteValue(TextAlignment.ToString());
+                writer.WriteStringValue(TextAlignment.ToString());
             }
 
             if (!string.IsNullOrEmpty(AttributedValue))
             {
                 writer.WritePropertyName("attributedValue");
-                writer.WriteValue(this.AttributedValue);
+                writer.WriteStringValue(AttributedValue);
             }
 
             if (Row.HasValue)
             {
                 writer.WritePropertyName("row");
-                writer.WriteValue(this.Row.Value);
+                writer.WriteNumberValue(Row.Value);
             }
 
             WriteKeys(writer);
@@ -144,7 +144,7 @@ namespace Passbook.Generator.Fields
             writer.WriteEndObject();
         }
 
-        private void WriteDataDetectorTypes(JsonWriter writer)
+        private void WriteDataDetectorTypes(Utf8JsonWriter writer)
         {
             if (DataDetectorTypes != DataDetectorTypes.PKDataDetectorAll)
             {
@@ -155,7 +155,7 @@ namespace Passbook.Generator.Fields
                     if (value.CompareTo(DataDetectorTypes.PKDataDetectorNone) != 0 &&
                         value.CompareTo(DataDetectorTypes.PKDataDetectorAll) != 0 &&
                         DataDetectorTypes.HasFlag(value))
-                        writer.WriteValue(value.ToString());
+                        writer.WriteStringValue(value.ToString());
 
                 writer.WriteEndArray();
             }
@@ -169,12 +169,12 @@ namespace Passbook.Generator.Fields
             }
         }
 
-        protected virtual void WriteKeys(JsonWriter writer)
+        protected virtual void WriteKeys(Utf8JsonWriter writer)
         {
             // NO OP
         }
 
-        protected abstract void WriteValue(JsonWriter writer);
+        protected abstract void WriteValue(Utf8JsonWriter writer);
 
         public abstract void SetValue(object value);
 

--- a/Passbook.Generator/Fields/NumberField.cs
+++ b/Passbook.Generator/Fields/NumberField.cs
@@ -1,4 +1,6 @@
-﻿namespace Passbook.Generator.Fields
+﻿using System.Text.Json;
+
+namespace Passbook.Generator.Fields
 {
     public class NumberField : Field
     {
@@ -9,8 +11,8 @@
         public NumberField(string key, string label, decimal value, FieldNumberStyle numberStyle)
             : base(key, label)
         {
-            this.Value = value;
-            this.NumberStyle = numberStyle;
+            Value = value;
+            NumberStyle = numberStyle;
         }
 
         public NumberField(string key, string label, int value, FieldNumberStyle numberStyle)
@@ -30,29 +32,29 @@
 
         public decimal Value { get; set; }
 
-        protected override void WriteKeys(Newtonsoft.Json.JsonWriter writer)
+        protected override void WriteKeys(Utf8JsonWriter writer)
         {
             if (!string.IsNullOrEmpty(CurrencyCode))
             {
                 writer.WritePropertyName("currencyCode");
-                writer.WriteValue(CurrencyCode);
+                writer.WriteStringValue(CurrencyCode);
             }
 
             if (NumberStyle != FieldNumberStyle.Unspecified)
             {
                 writer.WritePropertyName("numberStyle");
-                writer.WriteValue(NumberStyle.ToString());
+                writer.WriteStringValue(NumberStyle.ToString());
             }
         }
 
-        protected override void WriteValue(Newtonsoft.Json.JsonWriter writer)
+        protected override void WriteValue(Utf8JsonWriter writer)
         {
-            writer.WriteValue(Value);
+            writer.WriteNumberValue(Value);
         }
 
         public override void SetValue(object value)
         {
-            this.Value = (decimal)value;
+            Value = (decimal)value;
         }
 
         public override bool HasValue

--- a/Passbook.Generator/NFC.cs
+++ b/Passbook.Generator/NFC.cs
@@ -1,15 +1,8 @@
-﻿namespace Passbook.Generator
+﻿namespace Passbook.Generator;
+
+public class Nfc(string message, string encryptionPublicKey)
 {
-    public class Nfc
-    {
-        public Nfc(string message, string encryptionPublicKey)
-        {
-            Message = message;
-            EncryptionPublicKey = encryptionPublicKey;
-        }
+    public string Message { get; } = message;
 
-        public string Message { get; }
-
-        public string EncryptionPublicKey { get; }
-    }
+    public string EncryptionPublicKey { get; } = encryptionPublicKey;
 }

--- a/Passbook.Generator/Pass.cs
+++ b/Passbook.Generator/Pass.cs
@@ -1,25 +1,19 @@
 ﻿using System.IO;
 
-namespace Passbook.Generator
+namespace Passbook.Generator;
+
+public class Pass(string packagePathAndName)
 {
-    public class Pass
+    private string packagePathAndName = packagePathAndName;
+
+    public byte[] GetPackage()
     {
-        private string packagePathAndName;
+        byte[] contents = File.ReadAllBytes(packagePathAndName);
+        return contents;
+    }
 
-        public Pass(string packagePathAndName)
-        {
-            this.packagePathAndName = packagePathAndName;
-        }
-
-        public byte[] GetPackage()
-        {
-            byte[] contents = File.ReadAllBytes(packagePathAndName);
-            return contents;
-        }
-
-        public string PackageDirectory
-        {
-            get { return Path.GetDirectoryName(this.packagePathAndName); }
-        }
+    public string PackageDirectory
+    {
+        get { return Path.GetDirectoryName(packagePathAndName); }
     }
 }

--- a/Passbook.Generator/PassGenerator.cs
+++ b/Passbook.Generator/PassGenerator.cs
@@ -1,4 +1,3 @@
-using Newtonsoft.Json;
 using Passbook.Generator.Exceptions;
 using System;
 using System.Collections.Generic;
@@ -10,345 +9,324 @@ using System.Security.Cryptography;
 using System.Security.Cryptography.Pkcs;
 using System.Security.Cryptography.X509Certificates;
 using System.Text;
+using System.Text.Json;
 using System.Text.RegularExpressions;
 
-namespace Passbook.Generator
+namespace Passbook.Generator;
+
+public class PassGenerator
 {
-    public class PassGenerator
+    private byte[] passFile = null;
+    private byte[] signatureFile = null;
+    private byte[] manifestFile = null;
+    private Dictionary<string, byte[]> localizationFiles = null;
+    private byte[] pkPassFile = null;
+    private byte[] pkPassBundle = null;
+    private const string passTypePrefix = "Pass Type ID: ";
+
+    /// <summary>
+    /// Creates a byte array which contains one pkpass file
+    /// </summary>
+    /// <param name="generatorRequest">
+    /// An instance of a PassGeneratorRequest</param>
+    /// <returns>
+    /// A byte array which contains a zipped pkpass file.
+    /// </returns>
+    /// <exception cref="ArgumentNullException"></exception>
+    public byte[] Generate(PassGeneratorRequest generatorRequest)
     {
-        private byte[] passFile = null;
-        private byte[] signatureFile = null;
-        private byte[] manifestFile = null;
-        private Dictionary<string, byte[]> localizationFiles = null;
-        private byte[] pkPassFile = null;
-        private byte[] pkPassBundle = null;
-        private const string passTypePrefix = "Pass Type ID: ";
-
-        /// <summary>
-        /// Creates a byte array which contains one pkpass file
-        /// </summary>
-        /// <param name="generatorRequest">
-        /// An instance of a PassGeneratorRequest</param>
-        /// <returns>
-        /// A byte array which contains a zipped pkpass file.
-        /// </returns>
-        /// <exception cref="ArgumentNullException"></exception>
-        public byte[] Generate(PassGeneratorRequest generatorRequest)
+        if (generatorRequest == null)
         {
-            if (generatorRequest == null)
-            {
-                throw new ArgumentNullException(nameof(generatorRequest), "You must pass an instance of PassGeneratorRequest");
-            }
-
-            CreatePackage(generatorRequest);
-            ZipPackage(generatorRequest);
-
-            return pkPassFile;
+            throw new ArgumentNullException(nameof(generatorRequest), "You must pass an instance of PassGeneratorRequest");
         }
 
-        /// <summary>
-        /// Creates a byte array that can contains a .pkpasses file for bundling multiple passes together 
-        /// </summary>
-        /// <param name="generatorRequests">
-        /// A list of PassGeneratorRequest objects
-        /// </param>
-        /// <returns>
-        /// A byte array which contains a zipped pkpasses file.
-        /// </returns>
-        /// <exception cref="System.ArgumentNullException">
-        /// <exception cref="System.ArgumentException">
-        public byte[] Generate(IReadOnlyList<PassGeneratorRequest> generatorRequests)
+        CreatePackage(generatorRequest);
+        ZipPackage(generatorRequest);
+
+        return pkPassFile;
+    }
+
+    /// <summary>
+    /// Creates a byte array that can contains a .pkpasses file for bundling multiple passes together 
+    /// </summary>
+    /// <param name="generatorRequests">
+    /// A list of PassGeneratorRequest objects
+    /// </param>
+    /// <returns>
+    /// A byte array which contains a zipped pkpasses file.
+    /// </returns>
+    /// <exception cref="System.ArgumentNullException">
+    /// <exception cref="System.ArgumentException">
+    public byte[] Generate(IReadOnlyList<PassGeneratorRequest> generatorRequests)
+    {
+        if (generatorRequests == null)
         {
-            if (generatorRequests == null)
-            {
-                throw new ArgumentNullException(nameof(generatorRequests), "You must pass an instance of IReadOnlyList containing at least one PassGeneratorRequest");
-            }
-
-            if (!generatorRequests.Any())
-            {
-                throw new ArgumentException(nameof(generatorRequests), "The IReadOnlyList must contain at least one PassGeneratorRequest");
-            }
-
-            ZipBundle(generatorRequests);
-
-            return pkPassBundle;
+            throw new ArgumentNullException(nameof(generatorRequests), "You must pass an instance of IReadOnlyList containing at least one PassGeneratorRequest");
         }
 
-        private void ZipBundle(IEnumerable<PassGeneratorRequest> generatorRequests)
+        if (!generatorRequests.Any())
         {
-            using (MemoryStream zipToOpen = new MemoryStream())
+            throw new ArgumentException(nameof(generatorRequests), "The IReadOnlyList must contain at least one PassGeneratorRequest");
+        }
+
+        ZipBundle(generatorRequests);
+
+        return pkPassBundle;
+    }
+
+    private void ZipBundle(IEnumerable<PassGeneratorRequest> generatorRequests)
+    {
+        using (MemoryStream zipToOpen = new MemoryStream())
+        {
+            using (ZipArchive archive = new ZipArchive(zipToOpen, ZipArchiveMode.Create, true))
             {
-                using (ZipArchive archive = new ZipArchive(zipToOpen, ZipArchiveMode.Create, true))
+                int i = 0;
+
+                foreach (PassGeneratorRequest generatorRequest in generatorRequests)
                 {
-                    int i = 0;
+                    ZipArchiveEntry zipEntry = archive.CreateEntry($"pass{i++}.pkpass");
 
-                    foreach (PassGeneratorRequest generatorRequest in generatorRequests)
+                    CreatePackage(generatorRequest);
+                    ZipPackage(generatorRequest);
+
+                    using (MemoryStream originalFileStream = new MemoryStream(pkPassFile))
                     {
-                        ZipArchiveEntry zipEntry = archive.CreateEntry($"pass{i++}.pkpass");
-
-                        CreatePackage(generatorRequest);
-                        ZipPackage(generatorRequest);
-
-                        using (MemoryStream originalFileStream = new MemoryStream(pkPassFile))
+                        using (Stream zipEntryStream = zipEntry.Open())
                         {
-                            using (Stream zipEntryStream = zipEntry.Open())
-                            {
-                                originalFileStream.CopyTo(zipEntryStream);
-                            }
+                            originalFileStream.CopyTo(zipEntryStream);
                         }
                     }
                 }
-
-                pkPassBundle = zipToOpen.ToArray();
-
-                zipToOpen.Flush();
             }
+
+            pkPassBundle = zipToOpen.ToArray();
+
+            zipToOpen.Flush();
         }
+    }
 
-        private void ZipPackage(PassGeneratorRequest request)
+    private void ZipPackage(PassGeneratorRequest request)
+    {
+        using (MemoryStream zipToOpen = new MemoryStream())
         {
-            using (MemoryStream zipToOpen = new MemoryStream())
+            using (ZipArchive archive = new ZipArchive(zipToOpen, ZipArchiveMode.Update, true))
             {
-                using (ZipArchive archive = new ZipArchive(zipToOpen, ZipArchiveMode.Update, true))
+                foreach (KeyValuePair<PassbookImage, byte[]> image in request.Images)
                 {
-                    foreach (KeyValuePair<PassbookImage, byte[]> image in request.Images)
+                    ZipArchiveEntry imageEntry = archive.CreateEntry(image.Key.ToFilename());
+
+                    using (BinaryWriter writer = new BinaryWriter(imageEntry.Open()))
                     {
-                        ZipArchiveEntry imageEntry = archive.CreateEntry(image.Key.ToFilename());
-
-                        using (BinaryWriter writer = new BinaryWriter(imageEntry.Open()))
-                        {
-                            writer.Write(image.Value);
-                            writer.Flush();
-                        }
-                    }
-
-                    foreach (KeyValuePair<string, byte[]> localization in localizationFiles)
-                    {
-                        ZipArchiveEntry localizationEntry = archive.CreateEntry(string.Format("{0}.lproj/pass.strings", localization.Key.ToLower()));
-
-                        using (BinaryWriter writer = new BinaryWriter(localizationEntry.Open()))
-                        {
-                            writer.Write(localization.Value);
-                            writer.Flush();
-                        }
-                    }
-
-                    ZipArchiveEntry PassJSONEntry = archive.CreateEntry(@"pass.json");
-                    using (BinaryWriter writer = new BinaryWriter(PassJSONEntry.Open()))
-                    {
-                        writer.Write(passFile);
-                        writer.Flush();
-                    }
-
-                    ZipArchiveEntry ManifestJSONEntry = archive.CreateEntry(@"manifest.json");
-                    using (BinaryWriter writer = new BinaryWriter(ManifestJSONEntry.Open()))
-                    {
-                        writer.Write(manifestFile);
-                        writer.Flush();
-                    }
-
-                    ZipArchiveEntry SignatureEntry = archive.CreateEntry(@"signature");
-                    using (BinaryWriter writer = new BinaryWriter(SignatureEntry.Open()))
-                    {
-                        writer.Write(signatureFile);
+                        writer.Write(image.Value);
                         writer.Flush();
                     }
                 }
 
-                pkPassFile = zipToOpen.ToArray();
-                zipToOpen.Flush();
-            }
-        }
-
-        private void CreatePackage(PassGeneratorRequest request)
-        {
-            ValidateCertificates(request);
-            CreatePassFile(request);
-            GenerateLocalizationFiles(request);
-            GenerateManifestFile(request);
-        }
-
-        private void ValidateCertificates(PassGeneratorRequest request)
-        {
-            if (request.PassbookCertificate == null)
-            {
-                throw new FileNotFoundException("Certificate could not be found. Please ensure the thumbprint and cert location values are correct.");
-            }
-
-            if (request.AppleWWDRCACertificate == null)
-            {
-                throw new FileNotFoundException("Apple Certificate could not be found. Please download it from http://www.apple.com/certificateauthority/ and install it into your PERSONAL or LOCAL MACHINE certificate store.");
-            }
-
-            string passTypeIdentifier = request.PassbookCertificate.GetNameInfo(X509NameType.SimpleName, false);
-
-            if (passTypeIdentifier.StartsWith(passTypePrefix, StringComparison.OrdinalIgnoreCase))
-            {
-                passTypeIdentifier = passTypeIdentifier.Substring(passTypePrefix.Length);
-
-                if (!string.IsNullOrEmpty(passTypeIdentifier) && !string.Equals(request.PassTypeIdentifier, passTypeIdentifier, StringComparison.Ordinal))
+                foreach (KeyValuePair<string, byte[]> localization in localizationFiles)
                 {
-                    if (!string.IsNullOrEmpty(request.PassTypeIdentifier))
-                    {
-                        Trace.TraceWarning("Configured passTypeIdentifier {0} does not match pass certificate {1}, correcting.", request.PassTypeIdentifier, passTypeIdentifier);
-                    }
+                    ZipArchiveEntry localizationEntry = archive.CreateEntry(string.Format("{0}.lproj/pass.strings", localization.Key.ToLower()));
 
-                    request.PassTypeIdentifier = passTypeIdentifier;
+                    using (BinaryWriter writer = new BinaryWriter(localizationEntry.Open()))
+                    {
+                        writer.Write(localization.Value);
+                        writer.Flush();
+                    }
+                }
+
+                ZipArchiveEntry PassJSONEntry = archive.CreateEntry(@"pass.json");
+                using (BinaryWriter writer = new BinaryWriter(PassJSONEntry.Open()))
+                {
+                    writer.Write(passFile);
+                    writer.Flush();
+                }
+
+                ZipArchiveEntry ManifestJSONEntry = archive.CreateEntry(@"manifest.json");
+                using (BinaryWriter writer = new BinaryWriter(ManifestJSONEntry.Open()))
+                {
+                    writer.Write(manifestFile);
+                    writer.Flush();
+                }
+
+                ZipArchiveEntry SignatureEntry = archive.CreateEntry(@"signature");
+                using (BinaryWriter writer = new BinaryWriter(SignatureEntry.Open()))
+                {
+                    writer.Write(signatureFile);
+                    writer.Flush();
                 }
             }
 
-            Dictionary<string, string> nameParts =
-            Regex.Matches(request.PassbookCertificate.SubjectName.Name, @"(?<key>[^=,\s]+)\=*(?<value>("".+""|[^,])+)")
-              .Cast<Match>()
-              .ToDictionary(
-                  m => m.Groups["key"].Value,
-                  m => m.Groups["value"].Value);
+            pkPassFile = zipToOpen.ToArray();
+            zipToOpen.Flush();
+        }
+    }
 
-            string teamIdentifier;
+    private void CreatePackage(PassGeneratorRequest request)
+    {
+        ValidateCertificates(request);
+        CreatePassFile(request);
+        GenerateLocalizationFiles(request);
+        GenerateManifestFile(request);
+    }
 
-            if (nameParts.TryGetValue("OU", out teamIdentifier))
+    private void ValidateCertificates(PassGeneratorRequest request)
+    {
+        if (request.PassbookCertificate == null)
+        {
+            throw new FileNotFoundException("Certificate could not be found. Please ensure the thumbprint and cert location values are correct.");
+        }
+
+        if (request.AppleWWDRCACertificate == null)
+        {
+            throw new FileNotFoundException("Apple Certificate could not be found. Please download it from http://www.apple.com/certificateauthority/ and install it into your PERSONAL or LOCAL MACHINE certificate store.");
+        }
+
+        string passTypeIdentifier = request.PassbookCertificate.GetNameInfo(X509NameType.SimpleName, false);
+
+        if (passTypeIdentifier.StartsWith(passTypePrefix, StringComparison.OrdinalIgnoreCase))
+        {
+            passTypeIdentifier = passTypeIdentifier.Substring(passTypePrefix.Length);
+
+            if (!string.IsNullOrEmpty(passTypeIdentifier) && !string.Equals(request.PassTypeIdentifier, passTypeIdentifier, StringComparison.Ordinal))
             {
-                if (!string.IsNullOrEmpty(teamIdentifier) && !string.Equals(request.TeamIdentifier, teamIdentifier, StringComparison.Ordinal))
+                if (!string.IsNullOrEmpty(request.PassTypeIdentifier))
                 {
-                    if (!string.IsNullOrEmpty(request.TeamIdentifier))
-                    {
-                        Trace.TraceWarning("Configured teamidentifier {0} does not match pass certificate {1}, correcting.", request.TeamIdentifier, teamIdentifier);
-                    }
-
-                    request.TeamIdentifier = teamIdentifier;
+                    Trace.TraceWarning("Configured passTypeIdentifier {0} does not match pass certificate {1}, correcting.", request.PassTypeIdentifier, passTypeIdentifier);
                 }
+
+                request.PassTypeIdentifier = passTypeIdentifier;
             }
         }
 
-        private void CreatePassFile(PassGeneratorRequest request)
+        Dictionary<string, string> nameParts =
+        Regex.Matches(request.PassbookCertificate.SubjectName.Name, @"(?<key>[^=,\s]+)\=*(?<value>("".+""|[^,])+)")
+          .Cast<Match>()
+          .ToDictionary(
+              m => m.Groups["key"].Value,
+              m => m.Groups["value"].Value);
+
+        string teamIdentifier;
+
+        if (nameParts.TryGetValue("OU", out teamIdentifier))
         {
-            using (MemoryStream ms = new MemoryStream())
+            if (!string.IsNullOrEmpty(teamIdentifier) && !string.Equals(request.TeamIdentifier, teamIdentifier, StringComparison.Ordinal))
             {
-                using (StreamWriter sr = new StreamWriter(ms))
+                if (!string.IsNullOrEmpty(request.TeamIdentifier))
                 {
-                    using (JsonWriter writer = new JsonTextWriter(sr))
-                    {
-                        writer.Formatting = Formatting.Indented;
-
-                        Trace.TraceInformation("Writing JSON...");
-                        request.Write(writer);
-                    }
-
-                    passFile = ms.ToArray();
-                }
-            }
-        }
-
-        private void GenerateLocalizationFiles(PassGeneratorRequest request)
-        {
-            localizationFiles = new Dictionary<string, byte[]>(StringComparer.OrdinalIgnoreCase);
-
-            foreach (KeyValuePair<string, Dictionary<string, string>> localization in request.Localizations)
-            {
-                using (MemoryStream ms = new MemoryStream())
-                {
-                    using (StreamWriter sr = new StreamWriter(ms, Encoding.UTF8))
-                    {
-                        foreach (KeyValuePair<string, string> value in localization.Value)
-                        {
-                            sr.WriteLine("\"{0}\" = \"{1}\";\n", value.Key, value.Value);
-                        }
-
-                        sr.Flush();
-                        localizationFiles.Add(localization.Key, ms.ToArray());
-                    }
-                }
-            }
-        }
-
-        private void GenerateManifestFile(PassGeneratorRequest request)
-        {
-            using (MemoryStream ms = new MemoryStream())
-            {
-                using (StreamWriter sw = new StreamWriter(ms))
-                {
-                    using (JsonWriter jsonWriter = new JsonTextWriter(sw))
-                    {
-                        jsonWriter.Formatting = Formatting.Indented;
-                        jsonWriter.WriteStartObject();
-
-                        string hash = null;
-
-                        hash = GetHashForBytes(passFile);
-                        jsonWriter.WritePropertyName(@"pass.json");
-                        jsonWriter.WriteValue(hash);
-
-                        foreach (KeyValuePair<PassbookImage, byte[]> image in request.Images)
-                        {
-                            try
-                            {
-                                hash = GetHashForBytes(image.Value);
-                                jsonWriter.WritePropertyName(image.Key.ToFilename());
-                                jsonWriter.WriteValue(hash);
-                            }
-                            catch (Exception exception)
-                            {
-                                throw new Exception($"Unexpect error writing image on manifest file. Image Key: \"{image.Key}\"", exception);
-                            }
-                        }
-
-                        foreach (KeyValuePair<string, byte[]> localization in localizationFiles)
-                        {
-                            hash = GetHashForBytes(localization.Value);
-                            jsonWriter.WritePropertyName(string.Format("{0}.lproj/pass.strings", localization.Key.ToLower()));
-                            jsonWriter.WriteValue(hash);
-                        }
-                    }
-
-                    manifestFile = ms.ToArray();
+                    Trace.TraceWarning("Configured teamidentifier {0} does not match pass certificate {1}, correcting.", request.TeamIdentifier, teamIdentifier);
                 }
 
-                SignManifestFile(request);
+                request.TeamIdentifier = teamIdentifier;
             }
         }
+    }
 
-        private void SignManifestFile(PassGeneratorRequest request)
+    private void CreatePassFile(PassGeneratorRequest request)
+    {
+        using var ms = new MemoryStream();
+        var options = new JsonWriterOptions {Indented = true};
+        var writer = new Utf8JsonWriter(ms, options);
+        
+        Trace.TraceInformation("Writing JSON...");
+        request.Write(writer);
+
+        passFile = ms.ToArray();
+    }
+
+    private void GenerateLocalizationFiles(PassGeneratorRequest request)
+    {
+        localizationFiles = new Dictionary<string, byte[]>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (KeyValuePair<string, Dictionary<string, string>> localization in request.Localizations)
         {
-            Trace.TraceInformation("Signing the manifest file...");
+            using var ms = new MemoryStream();
+            using var sr = new StreamWriter(ms, Encoding.UTF8);
+            foreach (KeyValuePair<string, string> value in localization.Value)
+            {
+                sr.WriteLine("\"{0}\" = \"{1}\";\n", value.Key, value.Value);
+            }
 
+            sr.Flush();
+            localizationFiles.Add(localization.Key, ms.ToArray());
+        }
+    }
+
+    private void GenerateManifestFile(PassGeneratorRequest request)
+    {
+        using var ms = new MemoryStream();
+        var options = new JsonWriterOptions {Indented = true};
+        var jsonWriter = new Utf8JsonWriter(ms, options);
+        jsonWriter.WriteStartObject();
+
+        string hash = null;
+
+        hash = GetHashForBytes(passFile);
+        jsonWriter.WritePropertyName(@"pass.json");
+        jsonWriter.WriteStringValue(hash);
+
+        foreach (KeyValuePair<PassbookImage, byte[]> image in request.Images)
+        {
             try
             {
-                ContentInfo contentInfo = new ContentInfo(manifestFile);
-
-                SignedCms signing = new SignedCms(contentInfo, true);
-
-                CmsSigner signer = new CmsSigner(SubjectIdentifierType.SubjectKeyIdentifier, request.PassbookCertificate)
-                {
-                    IncludeOption = X509IncludeOption.None
-                };
-
-                Trace.TraceInformation("Fetching Apple Certificate for signing..");
-                Trace.TraceInformation("Constructing the certificate chain..");
-                signer.Certificates.Add(request.AppleWWDRCACertificate);
-                signer.Certificates.Add(request.PassbookCertificate);
-
-                signer.SignedAttributes.Add(new Pkcs9SigningTime());
-
-                Trace.TraceInformation("Processing the signature..");
-                signing.ComputeSignature(signer);
-
-                signatureFile = signing.Encode();
-
-                Trace.TraceInformation("The file has been successfully signed!");
+                hash = GetHashForBytes(image.Value);
+                jsonWriter.WritePropertyName(image.Key.ToFilename());
+                jsonWriter.WriteStringValue(hash);
             }
-            catch (Exception exp)
+            catch (Exception exception)
             {
-                Trace.TraceError("Failed to sign the manifest file: [{0}]", exp.Message);
-                throw new ManifestSigningException("Failed to sign manifest", exp);
+                throw new Exception($"Unexpect error writing image on manifest file. Image Key: \"{image.Key}\"", exception);
             }
         }
 
-        private string GetHashForBytes(byte[] bytes)
+        foreach (KeyValuePair<string, byte[]> localization in localizationFiles)
         {
-            using (SHA1CryptoServiceProvider hasher = new SHA1CryptoServiceProvider())
-            {
-                return BitConverter.ToString(hasher.ComputeHash(bytes)).Replace("-", string.Empty).ToLower();
-            }
+            hash = GetHashForBytes(localization.Value);
+            jsonWriter.WritePropertyName(string.Format("{0}.lproj/pass.strings", localization.Key.ToLower()));
+            jsonWriter.WriteStringValue(hash);
         }
+        manifestFile = ms.ToArray();
+
+        SignManifestFile(request);
+    }
+
+    private void SignManifestFile(PassGeneratorRequest request)
+    {
+        Trace.TraceInformation("Signing the manifest file...");
+
+        try
+        {
+            ContentInfo contentInfo = new ContentInfo(manifestFile);
+
+            SignedCms signing = new SignedCms(contentInfo, true);
+
+            CmsSigner signer = new CmsSigner(SubjectIdentifierType.SubjectKeyIdentifier, request.PassbookCertificate)
+            {
+                IncludeOption = X509IncludeOption.None
+            };
+
+            Trace.TraceInformation("Fetching Apple Certificate for signing..");
+            Trace.TraceInformation("Constructing the certificate chain..");
+            signer.Certificates.Add(request.AppleWWDRCACertificate);
+            signer.Certificates.Add(request.PassbookCertificate);
+
+            signer.SignedAttributes.Add(new Pkcs9SigningTime());
+
+            Trace.TraceInformation("Processing the signature..");
+            signing.ComputeSignature(signer);
+
+            signatureFile = signing.Encode();
+
+            Trace.TraceInformation("The file has been successfully signed!");
+        }
+        catch (Exception exp)
+        {
+            Trace.TraceError("Failed to sign the manifest file: [{0}]", exp.Message);
+            throw new ManifestSigningException("Failed to sign manifest", exp);
+        }
+    }
+
+    private string GetHashForBytes(byte[] bytes)
+    {
+        using SHA1 hasher = SHA1.Create();
+        return BitConverter.ToString(hasher.ComputeHash(bytes)).Replace("-", string.Empty).ToLower();
     }
 }

--- a/Passbook.Generator/PassGeneratorRequest.cs
+++ b/Passbook.Generator/PassGeneratorRequest.cs
@@ -1,4 +1,3 @@
-using Newtonsoft.Json;
 using Passbook.Generator.Exceptions;
 using Passbook.Generator.Fields;
 using System;
@@ -7,673 +6,675 @@ using System.Diagnostics;
 using System.Globalization;
 using System.Linq;
 using System.Security.Cryptography.X509Certificates;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 
-namespace Passbook.Generator
+namespace Passbook.Generator;
+
+public class PassGeneratorRequest
 {
-    public class PassGeneratorRequest
+    public PassGeneratorRequest()
     {
-        public PassGeneratorRequest()
+        SemanticTags = [];
+        HeaderFields = [];
+        PrimaryFields = [];
+        SecondaryFields = [];
+        AuxiliaryFields = [];
+        BackFields = [];
+        Images = [];
+        RelevantLocations = [];
+        RelevantBeacons = [];
+        AssociatedStoreIdentifiers = [];
+        Localizations = new Dictionary<string, Dictionary<string, string>>(StringComparer.OrdinalIgnoreCase);
+        Barcodes = [];
+        UserInfo = new Dictionary<string, object>();
+    }
+
+    #region Standard Keys
+
+    /// <summary>
+    /// Required. Pass type identifier, as issued by Apple. The value must correspond with your signing certificate.
+    /// </summary>
+    public string PassTypeIdentifier { get; set; }
+
+    /// <summary>
+    /// Required. Version of the file format. The value must be 1.
+    /// </summary>
+    public int FormatVersion { get { return 1; } }
+
+    /// <summary>
+    /// Required. Serial number that uniquely identifies the pass. No two passes with the same pass type identifier may have the same serial number.
+    /// </summary>
+    public string SerialNumber { get; set; }
+
+    /// <summary>
+    /// Required. A simple description of the pass
+    /// </summary>
+    public string Description { get; set; }
+
+    /// <summary>
+    /// Required. Team identifier of the organization that originated and signed the pass, as issued by Apple.
+    /// </summary>
+    public string TeamIdentifier { get; set; }
+
+    /// <summary>
+    /// Required. Display name of the organization that originated and signed the pass.
+    /// </summary>
+    public string OrganizationName { get; set; }
+
+    /// <summary>
+    /// Disables sharing of the pass.
+    /// </summary>
+    public bool SharingProhibited { get; set; }
+
+    #endregion
+
+    #region Images Files
+
+    /// <summary>
+    /// When using in memory, the binary of each image is put here.
+    /// </summary>
+    public Dictionary<PassbookImage, byte[]> Images { get; set; }
+
+    #endregion
+
+    #region Companion App Keys
+
+    #endregion
+
+    #region Expiration Keys
+
+    public DateTimeOffset? ExpirationDate { get; set; }
+
+    public bool? Voided { get; set; }
+
+    #endregion
+
+    #region Visual Appearance Keys
+
+    /// <summary>
+    /// Optional. Foreground color of the pass, specified as a CSS-style RGB triple. For example, rgb(100, 10, 110).
+    /// </summary>
+    public string ForegroundColor { get; set; }
+
+    /// <summary>
+    /// Optional. Background color of the pass, specified as an CSS-style RGB triple. For example, rgb(23, 187, 82).
+    /// </summary>
+    public string BackgroundColor { get; set; }
+
+    /// <summary>
+    /// Optional. Color of the label text, specified as a CSS-style RGB triple. For example, rgb(255, 255, 255).
+    /// If omitted, the label color is determined automatically.
+    /// </summary>
+    public string LabelColor { get; set; }
+
+    /// <summary>
+    /// Optional. Text displayed next to the logo on the pass.
+    /// </summary>
+    public string LogoText { get; set; }
+
+    /// <summary>
+    /// Optional. If true, the strip image is displayed without a shine effect. The default value is false.
+    /// </summary>
+    public bool? SuppressStripShine { get; set; }
+
+    /// <summary>
+    /// Optional. The semantic tags to add to the pass. Read more about them here https://developer.apple.com/documentation/walletpasses/semantictags
+    /// </summary>
+    public SemanticTags SemanticTags { get; }
+
+    /// <summary>
+    /// Optional. Fields to be displayed prominently on the front of the pass.
+    /// </summary>
+    public List<Field> HeaderFields { get; private set; }
+
+    /// <summary>
+    /// Optional. Fields to be displayed prominently on the front of the pass.
+    /// </summary>
+    public List<Field> PrimaryFields { get; private set; }
+
+    /// <summary>
+    /// Optional. Fields to be displayed on the front of the pass.
+    /// </summary>
+    public List<Field> SecondaryFields { get; private set; }
+
+    /// <summary>
+    /// Optional. Additional fields to be displayed on the front of the pass.
+    /// </summary>
+    public List<Field> AuxiliaryFields { get; private set; }
+
+    /// <summary>
+    /// Optional. Information about fields that are displayed on the back of the pass.
+    /// </summary>
+    public List<Field> BackFields { get; private set; }
+
+    /// <summary>
+    /// Optional. Information specific to barcodes.
+    /// </summary>
+    public Barcode Barcode { get; private set; }
+
+    /// <summary>
+    /// Required. Pass type.
+    /// </summary>
+    public PassStyle Style { get; set; }
+
+    /// <summary>
+    /// Required for boarding passes; otherwise not allowed. Type of transit.
+    /// </summary>
+    public TransitType TransitType { get; set; }
+
+    /// <summary>
+    /// Optional for event tickets and boarding passes; otherwise not allowed. Identifier used to group related passes
+    /// </summary>
+    public string GroupingIdentifier { get; set; }
+
+    #endregion
+
+    #region Relevance Keys
+
+    /// <summary>
+    /// Optional. Date and time when the pass becomes relevant. For example, the start time of a movie.
+    /// </summary>
+    public DateTimeOffset? RelevantDate { get; set; }
+
+    /// <summary>
+    /// Optional. Locations where the passisrelevant. For example, the location of your store.
+    /// </summary>
+    public List<RelevantLocation> RelevantLocations { get; private set; }
+
+    /// <summary>
+    /// Optional. Beacons marking locations where the pass is relevant.
+    /// </summary>
+    public List<RelevantBeacon> RelevantBeacons { get; private set; }
+
+    /// <summary>
+    /// Optional. Maximum distance in meters from a relevant latitude and longitude that the pass is relevant
+    /// </summary>
+    public int? MaxDistance { get; set; }
+
+    #endregion
+
+    #region Certificates
+
+    /// <summary>
+    /// A byte array containing the PassKit certificate
+    /// </summary>
+    public X509Certificate2 PassbookCertificate { get; set; }
+
+    /// <summary>
+    /// A byte array containing the Apple WWDRCA X509 certificate
+    /// </summary>
+    public X509Certificate2 AppleWWDRCACertificate { get; set; }
+
+    #endregion
+
+    #region Web Service Keys
+
+    /// <summary>
+    /// The authentication token to use with the web service.
+    /// </summary>
+    public string AuthenticationToken { get; set; }
+    /// <summary>
+    /// The URL of a web service that conforms to the API described in Pass Kit Web Service Reference.
+    /// The web service must use the HTTPS protocol and includes the leading https://.
+    /// On devices configured for development, there is UI in Settings to allow HTTP web services.
+    /// </summary>
+    public string WebServiceUrl { get; set; }
+
+    #endregion
+
+    #region Associated App Keys
+
+    public List<long> AssociatedStoreIdentifiers { get; set; }
+
+    public string AppLaunchURL { get; set; }
+
+    #endregion
+
+    #region Barcodes
+
+    public List<Barcode> Barcodes { get; private set; }
+
+    #endregion
+
+    #region User Info Keys
+
+    public IDictionary<string, object> UserInfo { get; set; }
+
+    #endregion
+
+    #region Localization
+    public Dictionary<string, Dictionary<string, string>> Localizations { get; set; }
+    #endregion
+
+    #region NFC
+
+    public Nfc Nfc { get; set; }
+
+    #endregion
+
+    #region Helpers and Serialization
+
+    public void AddHeaderField(Field field)
+    {
+        EnsureFieldKeyIsUnique(field.Key);
+        HeaderFields.Add(field);
+    }
+
+    public void AddPrimaryField(Field field)
+    {
+        EnsureFieldKeyIsUnique(field.Key);
+        PrimaryFields.Add(field);
+    }
+
+    public void AddSecondaryField(Field field)
+    {
+        EnsureFieldKeyIsUnique(field.Key);
+        SecondaryFields.Add(field);
+    }
+
+    public void AddAuxiliaryField(Field field)
+    {
+        EnsureFieldKeyIsUnique(field.Key);
+        AuxiliaryFields.Add(field);
+    }
+
+    public void AddBackField(Field field)
+    {
+        EnsureFieldKeyIsUnique(field.Key);
+        BackFields.Add(field);
+    }
+
+    private void EnsureFieldKeyIsUnique(string key)
+    {
+        if (HeaderFields.Any(x => x.Key == key) ||
+            PrimaryFields.Any(x => x.Key == key) ||
+            SecondaryFields.Any(x => x.Key == key) ||
+            AuxiliaryFields.Any(x => x.Key == key) ||
+            BackFields.Any(x => x.Key == key))
         {
-            SemanticTags = new SemanticTags();
-            HeaderFields = new List<Field>();
-            PrimaryFields = new List<Field>();
-            SecondaryFields = new List<Field>();
-            AuxiliaryFields = new List<Field>();
-            BackFields = new List<Field>();
-            Images = new Dictionary<PassbookImage, byte[]>();
-            RelevantLocations = new List<RelevantLocation>();
-            RelevantBeacons = new List<RelevantBeacon>();
-            AssociatedStoreIdentifiers = new List<long>();
-            Localizations = new Dictionary<string, Dictionary<string, string>>(StringComparer.OrdinalIgnoreCase);
-            Barcodes = new List<Barcode>();
-            UserInfo = new Dictionary<string, object>();
+            throw new DuplicateFieldKeyException(key);
+        }
+    }
+
+    public void AddBarcode(BarcodeType type, string message, string encoding, string alternateText)
+    {
+        Barcodes.Add(new Barcode(type, message, encoding, alternateText));
+    }
+
+    public void AddBarcode(BarcodeType type, string message, string encoding)
+    {
+        Barcodes.Add(new Barcode(type, message, encoding));
+    }
+
+    public void SetBarcode(BarcodeType type, string message, string encoding, string alternateText = null)
+    {
+        Barcode = new Barcode(type, message, encoding, alternateText);
+    }
+
+    public void AddLocation(double latitude, double longitude)
+    {
+        AddLocation(latitude, longitude, null);
+    }
+
+    public void AddLocation(double latitude, double longitude, string relevantText)
+    {
+        RelevantLocations.Add(new RelevantLocation() { Latitude = latitude, Longitude = longitude, RelevantText = relevantText });
+    }
+
+    public void AddBeacon(string proximityUUID, string relevantText)
+    {
+        RelevantBeacons.Add(new RelevantBeacon() { ProximityUUID = proximityUUID, RelevantText = relevantText });
+    }
+
+    public void AddBeacon(string proximityUUID, string relevantText, int major)
+    {
+        RelevantBeacons.Add(new RelevantBeacon() { ProximityUUID = proximityUUID, RelevantText = relevantText, Major = major });
+    }
+
+    public void AddBeacon(string proximityUUID, string relevantText, int major, int minor)
+    {
+        RelevantBeacons.Add(new RelevantBeacon() { ProximityUUID = proximityUUID, RelevantText = relevantText, Major = major, Minor = minor });
+    }
+
+    public void AddLocalization(string languageCode, string key, string value)
+    {
+        Dictionary<string, string> values;
+
+        if (!Localizations.TryGetValue(languageCode, out values))
+        {
+            values = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            Localizations.Add(languageCode, values);
         }
 
-        #region Standard Keys
+        values[key] = value;
+    }
 
-        /// <summary>
-        /// Required. Pass type identifier, as issued by Apple. The value must correspond with your signing certificate.
-        /// </summary>
-        public string PassTypeIdentifier { get; set; }
+    public virtual void PopulateFields()
+    {
+        // NO OP.
+    }
 
-        /// <summary>
-        /// Required. Version of the file format. The value must be 1.
-        /// </summary>
-        public int FormatVersion { get { return 1; } }
+    public void Write(Utf8JsonWriter writer)
+    {
+        PopulateFields();
 
-        /// <summary>
-        /// Required. Serial number that uniquely identifies the pass. No two passes with the same pass type identifier may have the same serial number.
-        /// </summary>
-        public string SerialNumber { get; set; }
+        writer.WriteStartObject();
 
-        /// <summary>
-        /// Required. A simple description of the pass
-        /// </summary>
-        public string Description { get; set; }
+        Trace.TraceInformation("Writing semantics..");
+        WriteSemantics(writer);
+        Trace.TraceInformation("Writing standard keys..");
+        WriteStandardKeys(writer);
+        Trace.TraceInformation("Writing user information..");
+        WriteUserInfo(writer);
+        Trace.TraceInformation("Writing relevance keys..");
+        WriteRelevanceKeys(writer);
+        Trace.TraceInformation("Writing appearance keys..");
+        WriteAppearanceKeys(writer);
+        Trace.TraceInformation("Writing expiration keys..");
+        WriteExpirationKeys(writer);
+        Trace.TraceInformation("Writing barcode keys..");
+        WriteBarcodes(writer);
 
-        /// <summary>
-        /// Required. Team identifier of the organization that originated and signed the pass, as issued by Apple.
-        /// </summary>
-        public string TeamIdentifier { get; set; }
-
-        /// <summary>
-        /// Required. Display name of the organization that originated and signed the pass.
-        /// </summary>
-        public string OrganizationName { get; set; }
-
-        /// <summary>
-        /// Disables sharing of the pass.
-        /// </summary>
-        public bool SharingProhibited { get; set; }
-
-        #endregion
-
-        #region Images Files
-
-        /// <summary>
-        /// When using in memory, the binary of each image is put here.
-        /// </summary>
-        public Dictionary<PassbookImage, byte[]> Images { get; set; }
-
-        #endregion
-
-        #region Companion App Keys
-
-        #endregion
-
-        #region Expiration Keys
-
-        public DateTimeOffset? ExpirationDate { get; set; }
-
-        public Boolean? Voided { get; set; }
-
-        #endregion
-
-        #region Visual Appearance Keys
-
-        /// <summary>
-        /// Optional. Foreground color of the pass, specified as a CSS-style RGB triple. For example, rgb(100, 10, 110).
-        /// </summary>
-        public string ForegroundColor { get; set; }
-
-        /// <summary>
-        /// Optional. Background color of the pass, specified as an CSS-style RGB triple. For example, rgb(23, 187, 82).
-        /// </summary>
-        public string BackgroundColor { get; set; }
-
-        /// <summary>
-        /// Optional. Color of the label text, specified as a CSS-style RGB triple. For example, rgb(255, 255, 255).
-        /// If omitted, the label color is determined automatically.
-        /// </summary>
-        public string LabelColor { get; set; }
-
-        /// <summary>
-        /// Optional. Text displayed next to the logo on the pass.
-        /// </summary>
-        public string LogoText { get; set; }
-
-        /// <summary>
-        /// Optional. If true, the strip image is displayed without a shine effect. The default value is false.
-        /// </summary>
-        public bool? SuppressStripShine { get; set; }
-
-        /// <summary>
-        /// Optional. The semantic tags to add to the pass. Read more about them here https://developer.apple.com/documentation/walletpasses/semantictags
-        /// </summary>
-        public SemanticTags SemanticTags { get; }
-
-        /// <summary>
-        /// Optional. Fields to be displayed prominently on the front of the pass.
-        /// </summary>
-        public List<Field> HeaderFields { get; private set; }
-
-        /// <summary>
-        /// Optional. Fields to be displayed prominently on the front of the pass.
-        /// </summary>
-        public List<Field> PrimaryFields { get; private set; }
-
-        /// <summary>
-        /// Optional. Fields to be displayed on the front of the pass.
-        /// </summary>
-        public List<Field> SecondaryFields { get; private set; }
-
-        /// <summary>
-        /// Optional. Additional fields to be displayed on the front of the pass.
-        /// </summary>
-        public List<Field> AuxiliaryFields { get; private set; }
-
-        /// <summary>
-        /// Optional. Information about fields that are displayed on the back of the pass.
-        /// </summary>
-        public List<Field> BackFields { get; private set; }
-
-        /// <summary>
-        /// Optional. Information specific to barcodes.
-        /// </summary>
-        public Barcode Barcode { get; private set; }
-
-        /// <summary>
-        /// Required. Pass type.
-        /// </summary>
-        public PassStyle Style { get; set; }
-
-        /// <summary>
-        /// Required for boarding passes; otherwise not allowed. Type of transit.
-        /// </summary>
-        public TransitType TransitType { get; set; }
-
-        /// <summary>
-        /// Optional for event tickets and boarding passes; otherwise not allowed. Identifier used to group related passes
-        /// </summary>
-        public string GroupingIdentifier { get; set; }
-
-        #endregion
-
-        #region Relevance Keys
-
-        /// <summary>
-        /// Optional. Date and time when the pass becomes relevant. For example, the start time of a movie.
-        /// </summary>
-        public DateTimeOffset? RelevantDate { get; set; }
-
-        /// <summary>
-        /// Optional. Locations where the passisrelevant. For example, the location of your store.
-        /// </summary>
-        public List<RelevantLocation> RelevantLocations { get; private set; }
-
-        /// <summary>
-        /// Optional. Beacons marking locations where the pass is relevant.
-        /// </summary>
-        public List<RelevantBeacon> RelevantBeacons { get; private set; }
-
-        /// <summary>
-        /// Optional. Maximum distance in meters from a relevant latitude and longitude that the pass is relevant
-        /// </summary>
-        public int? MaxDistance { get; set; }
-
-        #endregion
-
-        #region Certificates
-
-        /// <summary>
-        /// A byte array containing the PassKit certificate
-        /// </summary>
-        public X509Certificate2 PassbookCertificate { get; set; }
-
-        /// <summary>
-        /// A byte array containing the Apple WWDRCA X509 certificate
-        /// </summary>
-        public X509Certificate2 AppleWWDRCACertificate { get; set; }
-
-        #endregion
-
-        #region Web Service Keys
-
-        /// <summary>
-        /// The authentication token to use with the web service.
-        /// </summary>
-        public string AuthenticationToken { get; set; }
-        /// <summary>
-        /// The URL of a web service that conforms to the API described in Pass Kit Web Service Reference.
-        /// The web service must use the HTTPS protocol and includes the leading https://.
-        /// On devices configured for development, there is UI in Settings to allow HTTP web services.
-        /// </summary>
-        public string WebServiceUrl { get; set; }
-
-        #endregion
-
-        #region Associated App Keys
-
-        public List<long> AssociatedStoreIdentifiers { get; set; }
-
-        public string AppLaunchURL { get; set; }
-
-        #endregion
-
-        #region Barcodes
-
-        public List<Barcode> Barcodes { get; private set; }
-
-        #endregion
-
-        #region User Info Keys
-
-        public IDictionary<string, object> UserInfo { get; set; }
-
-        #endregion
-
-        #region Localization
-        public Dictionary<string, Dictionary<string, string>> Localizations { get; set; }
-        #endregion
-
-        #region NFC
-
-        public Nfc Nfc { get; set; }
-
-        #endregion
-
-        #region Helpers and Serialization
-
-        public void AddHeaderField(Field field)
+        if (Nfc != null)
         {
-            EnsureFieldKeyIsUnique(field.Key);
-            HeaderFields.Add(field);
+            Trace.TraceInformation("Writing NFC fields");
+            WriteNfcKeys(writer);
         }
 
-        public void AddPrimaryField(Field field)
+        Trace.TraceInformation("Opening style section..");
+        OpenStyleSpecificKey(writer);
+
+        Trace.TraceInformation("Writing header fields");
+        WriteSection(writer, "headerFields", HeaderFields);
+        Trace.TraceInformation("Writing primary fields");
+        WriteSection(writer, "primaryFields", PrimaryFields);
+        Trace.TraceInformation("Writing secondary fields");
+        WriteSection(writer, "secondaryFields", SecondaryFields);
+        Trace.TraceInformation("Writing auxiliary fields");
+        WriteSection(writer, "auxiliaryFields", AuxiliaryFields);
+        Trace.TraceInformation("Writing back fields");
+        WriteSection(writer, "backFields", BackFields);
+
+        if (Style == PassStyle.BoardingPass)
         {
-            EnsureFieldKeyIsUnique(field.Key);
-            PrimaryFields.Add(field);
+            writer.WritePropertyName("transitType");
+            writer.WriteStringValue(TransitType.ToString());
         }
 
-        public void AddSecondaryField(Field field)
+        Trace.TraceInformation("Closing style section..");
+        CloseStyleSpecificKey(writer);
+
+        WriteBarcode(writer);
+        WriteUrls(writer);
+
+        writer.WriteEndObject();
+    }
+
+    private void WriteRelevanceKeys(Utf8JsonWriter writer)
+    {
+        if (RelevantDate.HasValue)
         {
-            EnsureFieldKeyIsUnique(field.Key);
-            SecondaryFields.Add(field);
+            writer.WritePropertyName("relevantDate");
+            writer.WriteStringValue(RelevantDate.Value.ToString("yyyy-MM-ddTHH:mm:ssK"));
         }
 
-        public void AddAuxiliaryField(Field field)
+        if (MaxDistance.HasValue)
         {
-            EnsureFieldKeyIsUnique(field.Key);
-            AuxiliaryFields.Add(field);
+            writer.WritePropertyName("maxDistance");
+            writer.WriteStringValue(MaxDistance.Value.ToString());
         }
 
-        public void AddBackField(Field field)
+        if (RelevantLocations.Count > 0)
         {
-            EnsureFieldKeyIsUnique(field.Key);
-            BackFields.Add(field);
-        }
-
-        private void EnsureFieldKeyIsUnique(string key)
-        {
-            if (HeaderFields.Any(x => x.Key == key) ||
-                PrimaryFields.Any(x => x.Key == key) ||
-                SecondaryFields.Any(x => x.Key == key) ||
-                AuxiliaryFields.Any(x => x.Key == key) ||
-                BackFields.Any(x => x.Key == key))
-            {
-                throw new DuplicateFieldKeyException(key);
-            }
-        }
-
-        public void AddBarcode(BarcodeType type, string message, string encoding, string alternateText)
-        {
-            Barcodes.Add(new Barcode(type, message, encoding, alternateText));
-        }
-
-        public void AddBarcode(BarcodeType type, string message, string encoding)
-        {
-            Barcodes.Add(new Barcode(type, message, encoding));
-        }
-
-        public void SetBarcode(BarcodeType type, string message, string encoding, string alternateText = null)
-        {
-            Barcode = new Barcode(type, message, encoding, alternateText);
-        }
-
-        public void AddLocation(double latitude, double longitude)
-        {
-            AddLocation(latitude, longitude, null);
-        }
-
-        public void AddLocation(double latitude, double longitude, string relevantText)
-        {
-            RelevantLocations.Add(new RelevantLocation() { Latitude = latitude, Longitude = longitude, RelevantText = relevantText });
-        }
-
-        public void AddBeacon(string proximityUUID, string relevantText)
-        {
-            RelevantBeacons.Add(new RelevantBeacon() { ProximityUUID = proximityUUID, RelevantText = relevantText });
-        }
-
-        public void AddBeacon(string proximityUUID, string relevantText, int major)
-        {
-            RelevantBeacons.Add(new RelevantBeacon() { ProximityUUID = proximityUUID, RelevantText = relevantText, Major = major });
-        }
-
-        public void AddBeacon(string proximityUUID, string relevantText, int major, int minor)
-        {
-            RelevantBeacons.Add(new RelevantBeacon() { ProximityUUID = proximityUUID, RelevantText = relevantText, Major = major, Minor = minor });
-        }
-
-        public void AddLocalization(string languageCode, string key, string value)
-        {
-            Dictionary<string, string> values;
-
-            if (!Localizations.TryGetValue(languageCode, out values))
-            {
-                values = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
-                Localizations.Add(languageCode, values);
-            }
-
-            values[key] = value;
-        }
-
-        public virtual void PopulateFields()
-        {
-            // NO OP.
-        }
-
-        public void Write(JsonWriter writer)
-        {
-            PopulateFields();
-
-            writer.WriteStartObject();
-
-            Trace.TraceInformation("Writing semantics..");
-            WriteSemantics(writer);
-            Trace.TraceInformation("Writing standard keys..");
-            WriteStandardKeys(writer);
-            Trace.TraceInformation("Writing user information..");
-            WriteUserInfo(writer);
-            Trace.TraceInformation("Writing relevance keys..");
-            WriteRelevanceKeys(writer);
-            Trace.TraceInformation("Writing appearance keys..");
-            WriteAppearanceKeys(writer);
-            Trace.TraceInformation("Writing expiration keys..");
-            WriteExpirationKeys(writer);
-            Trace.TraceInformation("Writing barcode keys..");
-            WriteBarcodes(writer);
-
-            if (Nfc != null)
-            {
-                Trace.TraceInformation("Writing NFC fields");
-                WriteNfcKeys(writer);
-            }
-
-            Trace.TraceInformation("Opening style section..");
-            OpenStyleSpecificKey(writer);
-
-            Trace.TraceInformation("Writing header fields");
-            WriteSection(writer, "headerFields", this.HeaderFields);
-            Trace.TraceInformation("Writing primary fields");
-            WriteSection(writer, "primaryFields", this.PrimaryFields);
-            Trace.TraceInformation("Writing secondary fields");
-            WriteSection(writer, "secondaryFields", this.SecondaryFields);
-            Trace.TraceInformation("Writing auxiliary fields");
-            WriteSection(writer, "auxiliaryFields", this.AuxiliaryFields);
-            Trace.TraceInformation("Writing back fields");
-            WriteSection(writer, "backFields", this.BackFields);
-
-            if (this.Style == PassStyle.BoardingPass)
-            {
-                writer.WritePropertyName("transitType");
-                writer.WriteValue(this.TransitType.ToString());
-            }
-
-            Trace.TraceInformation("Closing style section..");
-            CloseStyleSpecificKey(writer);
-
-            WriteBarcode(writer);
-            WriteUrls(writer);
-
-            writer.WriteEndObject();
-        }
-
-        private void WriteRelevanceKeys(JsonWriter writer)
-        {
-            if (RelevantDate.HasValue)
-            {
-                writer.WritePropertyName("relevantDate");
-                writer.WriteValue(RelevantDate.Value.ToString("yyyy-MM-ddTHH:mm:ssK"));
-            }
-
-            if (MaxDistance.HasValue)
-            {
-                writer.WritePropertyName("maxDistance");
-                writer.WriteValue(MaxDistance.Value.ToString());
-            }
-
-            if (RelevantLocations.Count > 0)
-            {
-                writer.WritePropertyName("locations");
-                writer.WriteStartArray();
-
-                foreach (var location in RelevantLocations)
-                {
-                    location.Write(writer);
-                }
-
-                writer.WriteEndArray();
-            }
-
-            if (RelevantBeacons.Count > 0)
-            {
-                writer.WritePropertyName("beacons");
-                writer.WriteStartArray();
-
-                foreach (var beacon in RelevantBeacons)
-                {
-                    beacon.Write(writer);
-                }
-
-                writer.WriteEndArray();
-            }
-        }
-
-        private void WriteUrls(JsonWriter writer)
-        {
-            if (!string.IsNullOrEmpty(AuthenticationToken))
-            {
-                writer.WritePropertyName("authenticationToken");
-                writer.WriteValue(AuthenticationToken);
-                writer.WritePropertyName("webServiceURL");
-                writer.WriteValue(WebServiceUrl);
-            }
-        }
-
-        private void WriteBarcode(JsonWriter writer)
-        {
-            if (Barcode != null)
-            {
-                writer.WritePropertyName("barcode");
-                Barcode.Write(writer);
-            }
-        }
-
-        private void WriteBarcodes(JsonWriter writer)
-        {
-            if (Barcodes.Count > 0)
-            {
-                writer.WritePropertyName("barcodes");
-                writer.WriteStartArray();
-
-                foreach (var barcode in Barcodes)
-                {
-                    barcode.Write(writer);
-                }
-
-                writer.WriteEndArray();
-            }
-        }
-
-        private void WriteSemantics(JsonWriter writer)
-        {
-            SemanticTags.Write(writer);
-        }
-
-        private void WriteStandardKeys(JsonWriter writer)
-        {
-            writer.WritePropertyName("passTypeIdentifier");
-            writer.WriteValue(PassTypeIdentifier);
-
-            writer.WritePropertyName("formatVersion");
-            writer.WriteValue(FormatVersion);
-
-            writer.WritePropertyName("serialNumber");
-            writer.WriteValue(SerialNumber);
-
-            writer.WritePropertyName("description");
-            writer.WriteValue(Description);
-
-            writer.WritePropertyName("organizationName");
-            writer.WriteValue(OrganizationName);
-
-            writer.WritePropertyName("teamIdentifier");
-            writer.WriteValue(TeamIdentifier);
-
-            writer.WritePropertyName("sharingProhibited");
-            writer.WriteValue(SharingProhibited);
-
-            if (!String.IsNullOrEmpty(LogoText))
-            {
-                writer.WritePropertyName("logoText");
-                writer.WriteValue(LogoText);
-            }
-
-            if (AssociatedStoreIdentifiers.Count > 0)
-            {
-                writer.WritePropertyName("associatedStoreIdentifiers");
-                writer.WriteStartArray();
-
-                foreach (var storeIdentifier in AssociatedStoreIdentifiers)
-                {
-                    writer.WriteValue(storeIdentifier);
-                }
-
-                writer.WriteEndArray();
-            }
-
-            if (!string.IsNullOrEmpty(AppLaunchURL))
-            {
-                writer.WritePropertyName("appLaunchURL");
-                writer.WriteValue(AppLaunchURL);
-            }
-        }
-
-        private void WriteUserInfo(JsonWriter writer)
-        {
-            if (UserInfo != null)
-            {
-                writer.WritePropertyName("userInfo");
-                writer.WriteRawValue(JsonConvert.SerializeObject(UserInfo));
-            }
-        }
-
-        private void WriteAppearanceKeys(JsonWriter writer)
-        {
-            if (!String.IsNullOrEmpty(ForegroundColor))
-            {
-                writer.WritePropertyName("foregroundColor");
-                writer.WriteValue(ConvertColor(ForegroundColor));
-            }
-
-            if (!String.IsNullOrEmpty(BackgroundColor))
-            {
-                writer.WritePropertyName("backgroundColor");
-                writer.WriteValue(ConvertColor(BackgroundColor));
-            }
-
-            if (!String.IsNullOrEmpty(LabelColor))
-            {
-                writer.WritePropertyName("labelColor");
-                writer.WriteValue(ConvertColor(LabelColor));
-            }
-
-            if (SuppressStripShine.HasValue)
-            {
-                writer.WritePropertyName("suppressStripShine");
-                writer.WriteValue(SuppressStripShine.Value);
-            }
-
-            if (!String.IsNullOrEmpty(GroupingIdentifier))
-            {
-                writer.WritePropertyName("groupingIdentifier");
-                writer.WriteValue(GroupingIdentifier);
-            }
-        }
-
-        private void WriteExpirationKeys(JsonWriter writer)
-        {
-            if (ExpirationDate.HasValue)
-            {
-                writer.WritePropertyName("expirationDate");
-                writer.WriteValue(ExpirationDate.Value.ToString("yyyy-MM-ddTHH:mm:ssK"));
-            }
-
-            if (Voided.HasValue)
-            {
-                writer.WritePropertyName("voided");
-                writer.WriteValue(Voided.Value);
-            }
-        }
-
-        private void OpenStyleSpecificKey(JsonWriter writer)
-        {
-            string key = Style.ToString();
-
-            writer.WritePropertyName(char.ToLowerInvariant(key[0]) + key.Substring(1));
-            writer.WriteStartObject();
-        }
-
-        private static void CloseStyleSpecificKey(JsonWriter writer)
-        {
-            writer.WriteEndObject();
-        }
-
-        private static void WriteSection(JsonWriter writer, string sectionName, List<Field> fields)
-        {
-            writer.WritePropertyName(sectionName);
+            writer.WritePropertyName("locations");
             writer.WriteStartArray();
 
-            foreach (var field in fields)
+            foreach (var location in RelevantLocations)
             {
-                field.Write(writer);
+                location.Write(writer);
             }
 
             writer.WriteEndArray();
         }
 
-        private void WriteNfcKeys(JsonWriter writer)
+        if (RelevantBeacons.Count > 0)
         {
-            if (!string.IsNullOrEmpty(Nfc.Message))
+            writer.WritePropertyName("beacons");
+            writer.WriteStartArray();
+
+            foreach (var beacon in RelevantBeacons)
             {
-                writer.WritePropertyName("nfc");
-                writer.WriteStartObject();
-                writer.WritePropertyName("message");
-                writer.WriteValue(Nfc.Message);
-
-                if (!string.IsNullOrEmpty(Nfc.EncryptionPublicKey))
-                {
-                    writer.WritePropertyName("encryptionPublicKey");
-                    writer.WriteValue(Nfc.EncryptionPublicKey);
-                }
-
-                writer.WriteEndObject();
+                beacon.Write(writer);
             }
+
+            writer.WriteEndArray();
+        }
+    }
+
+    private void WriteUrls(Utf8JsonWriter writer)
+    {
+        if (!string.IsNullOrEmpty(AuthenticationToken))
+        {
+            writer.WritePropertyName("authenticationToken");
+            writer.WriteStringValue(AuthenticationToken);
+            writer.WritePropertyName("webServiceURL");
+            writer.WriteStringValue(WebServiceUrl);
+        }
+    }
+
+    private void WriteBarcode(Utf8JsonWriter writer)
+    {
+        if (Barcode != null)
+        {
+            writer.WritePropertyName("barcode");
+            Barcode.Write(writer);
+        }
+    }
+
+    private void WriteBarcodes(Utf8JsonWriter writer)
+    {
+        if (Barcodes.Count > 0)
+        {
+            writer.WritePropertyName("barcodes");
+            writer.WriteStartArray();
+
+            foreach (var barcode in Barcodes)
+            {
+                barcode.Write(writer);
+            }
+
+            writer.WriteEndArray();
+        }
+    }
+
+    private void WriteSemantics(Utf8JsonWriter writer)
+    {
+        SemanticTags.Write(writer);
+    }
+
+    private void WriteStandardKeys(Utf8JsonWriter writer)
+    {
+        writer.WritePropertyName("passTypeIdentifier");
+        writer.WriteStringValue(PassTypeIdentifier);
+
+        writer.WritePropertyName("formatVersion");
+        writer.WriteNumberValue(FormatVersion);
+
+        writer.WritePropertyName("serialNumber");
+        writer.WriteStringValue(SerialNumber);
+
+        writer.WritePropertyName("description");
+        writer.WriteStringValue(Description);
+
+        writer.WritePropertyName("organizationName");
+        writer.WriteStringValue(OrganizationName);
+
+        writer.WritePropertyName("teamIdentifier");
+        writer.WriteStringValue(TeamIdentifier);
+
+        writer.WritePropertyName("sharingProhibited");
+        writer.WriteBooleanValue(SharingProhibited);
+
+        if (!string.IsNullOrEmpty(LogoText))
+        {
+            writer.WritePropertyName("logoText");
+            writer.WriteStringValue(LogoText);
         }
 
-        private static string ConvertColor(string color)
+        if (AssociatedStoreIdentifiers.Count > 0)
         {
-            if (!string.IsNullOrEmpty(color) && color.Substring(0, 1) == "#")
+            writer.WritePropertyName("associatedStoreIdentifiers");
+            writer.WriteStartArray();
+
+            foreach (var storeIdentifier in AssociatedStoreIdentifiers)
             {
-                int r, g, b;
+                writer.WriteNumberValue(storeIdentifier);
+            }
 
-                if (color.Length == 3)
-                {
-                    r = int.Parse(color.Substring(1, 1), NumberStyles.HexNumber);
-                    g = int.Parse(color.Substring(2, 1), NumberStyles.HexNumber);
-                    b = int.Parse(color.Substring(3, 1), NumberStyles.HexNumber);
-                }
-                else if (color.Length >= 6)
-                {
-                    r = int.Parse(color.Substring(1, 2), NumberStyles.HexNumber);
-                    g = int.Parse(color.Substring(3, 2), NumberStyles.HexNumber);
-                    b = int.Parse(color.Substring(5, 2), NumberStyles.HexNumber);
-                }
-                else
-                {
-                    throw new ArgumentException("use #rgb or #rrggbb for color values", color);
-                }
+            writer.WriteEndArray();
+        }
 
-                return $"rgb({r},{g},{b})";
+        if (!string.IsNullOrEmpty(AppLaunchURL))
+        {
+            writer.WritePropertyName("appLaunchURL");
+            writer.WriteStringValue(AppLaunchURL);
+        }
+    }
+
+    private void WriteUserInfo(Utf8JsonWriter writer)
+    {
+        if (UserInfo != null)
+        {
+            writer.WritePropertyName("userInfo");
+            string json = JsonSerializer.Serialize(UserInfo);
+            writer.WriteRawValue(json);
+        }
+    }
+
+    private void WriteAppearanceKeys(Utf8JsonWriter writer)
+    {
+        if (!string.IsNullOrEmpty(ForegroundColor))
+        {
+            writer.WritePropertyName("foregroundColor");
+            writer.WriteStringValue(ConvertColor(ForegroundColor));
+        }
+
+        if (!string.IsNullOrEmpty(BackgroundColor))
+        {
+            writer.WritePropertyName("backgroundColor");
+            writer.WriteStringValue(ConvertColor(BackgroundColor));
+        }
+
+        if (!string.IsNullOrEmpty(LabelColor))
+        {
+            writer.WritePropertyName("labelColor");
+            writer.WriteStringValue(ConvertColor(LabelColor));
+        }
+
+        if (SuppressStripShine.HasValue)
+        {
+            writer.WritePropertyName("suppressStripShine");
+            writer.WriteBooleanValue(SuppressStripShine.Value);
+        }
+
+        if (!string.IsNullOrEmpty(GroupingIdentifier))
+        {
+            writer.WritePropertyName("groupingIdentifier");
+            writer.WriteStringValue(GroupingIdentifier);
+        }
+    }
+
+    private void WriteExpirationKeys(Utf8JsonWriter writer)
+    {
+        if (ExpirationDate.HasValue)
+        {
+            writer.WritePropertyName("expirationDate");
+            writer.WriteStringValue(ExpirationDate.Value.ToString("yyyy-MM-ddTHH:mm:ssK"));
+        }
+
+        if (Voided.HasValue)
+        {
+            writer.WritePropertyName("voided");
+            writer.WriteBooleanValue(Voided.Value);
+        }
+    }
+
+    private void OpenStyleSpecificKey(Utf8JsonWriter writer)
+    {
+        string key = Style.ToString();
+
+        writer.WritePropertyName(char.ToLowerInvariant(key[0]) + key.Substring(1));
+        writer.WriteStartObject();
+    }
+
+    private static void CloseStyleSpecificKey(Utf8JsonWriter writer)
+    {
+        writer.WriteEndObject();
+    }
+
+    private static void WriteSection(Utf8JsonWriter writer, string sectionName, List<Field> fields)
+    {
+        writer.WritePropertyName(sectionName);
+        writer.WriteStartArray();
+
+        foreach (var field in fields)
+        {
+            field.Write(writer);
+        }
+
+        writer.WriteEndArray();
+    }
+
+    private void WriteNfcKeys(Utf8JsonWriter writer)
+    {
+        if (!string.IsNullOrEmpty(Nfc.Message))
+        {
+            writer.WritePropertyName("nfc");
+            writer.WriteStartObject();
+            writer.WritePropertyName("message");
+            writer.WriteStringValue(Nfc.Message);
+
+            if (!string.IsNullOrEmpty(Nfc.EncryptionPublicKey))
+            {
+                writer.WritePropertyName("encryptionPublicKey");
+                writer.WriteStringValue(Nfc.EncryptionPublicKey);
+            }
+
+            writer.WriteEndObject();
+        }
+    }
+
+    private static string ConvertColor(string color)
+    {
+        if (!string.IsNullOrEmpty(color) && color.Substring(0, 1) == "#")
+        {
+            int r, g, b;
+
+            if (color.Length == 3)
+            {
+                r = int.Parse(color.Substring(1, 1), NumberStyles.HexNumber);
+                g = int.Parse(color.Substring(2, 1), NumberStyles.HexNumber);
+                b = int.Parse(color.Substring(3, 1), NumberStyles.HexNumber);
+            }
+            else if (color.Length >= 6)
+            {
+                r = int.Parse(color.Substring(1, 2), NumberStyles.HexNumber);
+                g = int.Parse(color.Substring(3, 2), NumberStyles.HexNumber);
+                b = int.Parse(color.Substring(5, 2), NumberStyles.HexNumber);
             }
             else
             {
-                return color;
+                throw new ArgumentException("use #rgb or #rrggbb for color values", color);
             }
-        }
 
-        #endregion
+            return $"rgb({r},{g},{b})";
+        }
+        else
+        {
+            return color;
+        }
     }
+
+    #endregion
 }

--- a/Passbook.Generator/PassStyle.cs
+++ b/Passbook.Generator/PassStyle.cs
@@ -1,14 +1,13 @@
-﻿namespace Passbook.Generator
+﻿namespace Passbook.Generator;
+
+/// <summary>
+/// 
+/// </summary>
+public enum PassStyle
 {
-    /// <summary>
-    /// 
-    /// </summary>
-    public enum PassStyle
-    {
-        Generic,
-        BoardingPass,
-        Coupon,
-        EventTicket,
-        StoreCard
-    }
+    Generic,
+    BoardingPass,
+    Coupon,
+    EventTicket,
+    StoreCard
 }

--- a/Passbook.Generator/Passbook.Generator.csproj
+++ b/Passbook.Generator/Passbook.Generator.csproj
@@ -1,12 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <Version>3.2.4.0</Version>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
     <PackageId>dotnet-passbook</PackageId>
     <Company>Tomas McGuinness</Company>
     <Product>dotnet-passbook</Product>
+    <TargetFrameworks>net8.0</TargetFrameworks>
     <Description>Generate pass files for Apple Wallet. This library allows you to build and sign a pkpass file.</Description>
     <PackageReleaseNotes>Fix issue where some Associated Store Identifier values where not being handled correctly (GitHub issue #179)</PackageReleaseNotes>
     <PackageTags>PassBook Wallet Apple Passkit</PackageTags>
@@ -27,15 +27,9 @@
       <PackagePath></PackagePath>
     </None>
   </ItemGroup>
- <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">
-    <Reference Include="System.IO.Compression" />
-    <Reference Include="System.Security" />
-  </ItemGroup>
+
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-  </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
-    <PackageReference Include="System.Security.Cryptography.Pkcs" Version="4.7.0" />
+    <PackageReference Include="System.Security.Cryptography.Pkcs" Version="8.0.1" />
   </ItemGroup>
 
 </Project>

--- a/Passbook.Generator/RelevantBeacon.cs
+++ b/Passbook.Generator/RelevantBeacon.cs
@@ -1,60 +1,59 @@
-﻿using Newtonsoft.Json;
+﻿using System.Text.Json;
 using Passbook.Generator.Exceptions;
 
-namespace Passbook.Generator
+namespace Passbook.Generator;
+
+public class RelevantBeacon
 {
-    public class RelevantBeacon
+    /// <summary>
+    /// Required. Unique identifier of a Bluetooth Low Energy location beacon.
+    /// </summary>
+    public string ProximityUUID { get; set; }
+
+    /// <summary>
+    /// Optional. Text displayed on the lock screen when the pass is currently relevant.
+    /// </summary>
+    public string RelevantText { get; set; }
+
+    public int? Major { get; set; }
+
+    public int? Minor { get; set; }
+
+    public void Write(Utf8JsonWriter writer)
     {
-        /// <summary>
-        /// Required. Unique identifier of a Bluetooth Low Energy location beacon.
-        /// </summary>
-        public string ProximityUUID { get; set; }
+        Validate();
 
-        /// <summary>
-        /// Optional. Text displayed on the lock screen when the pass is currently relevant.
-        /// </summary>
-        public string RelevantText { get; set; }
+        writer.WriteStartObject();
 
-        public int? Major { get; set; }
+        writer.WritePropertyName("proximityUUID");
+        writer.WriteStringValue(ProximityUUID);
 
-        public int? Minor { get; set; }
-
-        public void Write(JsonWriter writer)
+        if (!string.IsNullOrEmpty(RelevantText))
         {
-            Validate();
-
-            writer.WriteStartObject();
-
-            writer.WritePropertyName("proximityUUID");
-            writer.WriteValue(ProximityUUID);
-
-            if (!string.IsNullOrEmpty(RelevantText))
-            {
-                writer.WritePropertyName("relevantText");
-                writer.WriteValue(RelevantText);
-            }
-
-            if (Minor.HasValue)
-            {
-                writer.WritePropertyName("minor");
-                writer.WriteValue(Minor);
-            }
-
-            if (Major.HasValue)
-            {
-                writer.WritePropertyName("major");
-                writer.WriteValue(Major);
-            }
-
-            writer.WriteEndObject();
+            writer.WritePropertyName("relevantText");
+            writer.WriteStringValue(RelevantText);
         }
 
-        private void Validate()
+        if (Minor.HasValue)
         {
-            if (string.IsNullOrEmpty(ProximityUUID))
-            {
-                throw new RequiredFieldValueMissingException("ProximityUUID");
-            }
+            writer.WritePropertyName("minor");
+            writer.WriteNumberValue(Minor.Value);
+        }
+
+        if (Major.HasValue)
+        {
+            writer.WritePropertyName("major");
+            writer.WriteNumberValue(Major.Value);
+        }
+
+        writer.WriteEndObject();
+    }
+
+    private void Validate()
+    {
+        if (string.IsNullOrEmpty(ProximityUUID))
+        {
+            throw new RequiredFieldValueMissingException("ProximityUUID");
         }
     }
 }

--- a/Passbook.Generator/RelevantLocation.cs
+++ b/Passbook.Generator/RelevantLocation.cs
@@ -1,68 +1,67 @@
-﻿using Newtonsoft.Json;
+﻿using System.Text.Json;
 using Passbook.Generator.Exceptions;
 
-namespace Passbook.Generator
+namespace Passbook.Generator;
+
+public class RelevantLocation
 {
-    public class RelevantLocation
+    /// <summary>
+    /// Optional. Altitude, in meters, of the location.
+    /// </summary>
+    public double? Altitude { get; set; }
+
+    /// <summary>
+    /// Required. Latitude, in degrees, of the location.
+    /// </summary>
+    public double Latitude { get; set; }
+
+    /// <summary>
+    /// Required. Longitude, in degrees, of the location.
+    /// </summary>
+    public double Longitude { get; set; }
+
+    /// <summary>
+    /// Optional. Text displayed on the lock screen when the pass is currently relevant.
+    /// </summary>
+    public string RelevantText { get; set; }
+
+    public void Write(Utf8JsonWriter writer)
     {
-        /// <summary>
-        /// Optional. Altitude, in meters, of the location.
-        /// </summary>
-        public double? Altitude { get; set; }
+        Validate();
 
-        /// <summary>
-        /// Required. Latitude, in degrees, of the location.
-        /// </summary>
-        public double Latitude { get; set; }
+        writer.WriteStartObject();
 
-        /// <summary>
-        /// Required. Longitude, in degrees, of the location.
-        /// </summary>
-        public double Longitude { get; set; }
-
-        /// <summary>
-        /// Optional. Text displayed on the lock screen when the pass is currently relevant.
-        /// </summary>
-        public string RelevantText { get; set; }
-
-        public void Write(JsonWriter writer)
+        if (Altitude.HasValue)
         {
-            Validate();
-
-            writer.WriteStartObject();
-
-            if (Altitude.HasValue)
-            {
-                writer.WritePropertyName("altitude");
-                writer.WriteValue(Altitude.Value);
-            }
-
-            writer.WritePropertyName("latitude");
-            writer.WriteValue(Latitude);
-
-            writer.WritePropertyName("longitude");
-            writer.WriteValue(Longitude);
-
-            if (RelevantText != null)
-            {
-                writer.WritePropertyName("relevantText");
-                writer.WriteValue(RelevantText);
-            }
-
-            writer.WriteEndObject();
+            writer.WritePropertyName("altitude");
+            writer.WriteNumberValue(Altitude.Value);
         }
 
-        private void Validate()
-        {
-            if (Latitude == double.MinValue)
-            {
-                throw new RequiredFieldValueMissingException("latitude");
-            }
+        writer.WritePropertyName("latitude");
+        writer.WriteNumberValue(Latitude);
 
-            if (Longitude == double.MinValue)
-            {
-                throw new RequiredFieldValueMissingException("longitude");
-            }
+        writer.WritePropertyName("longitude");
+        writer.WriteNumberValue(Longitude);
+
+        if (RelevantText != null)
+        {
+            writer.WritePropertyName("relevantText");
+            writer.WriteStringValue(RelevantText);
+        }
+
+        writer.WriteEndObject();
+    }
+
+    private void Validate()
+    {
+        if (Latitude == double.MinValue)
+        {
+            throw new RequiredFieldValueMissingException("latitude");
+        }
+
+        if (Longitude == double.MinValue)
+        {
+            throw new RequiredFieldValueMissingException("longitude");
         }
     }
 }

--- a/Passbook.Generator/SemanticTags.cs
+++ b/Passbook.Generator/SemanticTags.cs
@@ -1,23 +1,21 @@
-﻿using Newtonsoft.Json;
-using Passbook.Generator.Tags;
+﻿using Passbook.Generator.Tags;
 using System.Collections.Generic;
-using System.Text;
+using System.Text.Json;
 
-namespace Passbook.Generator
+namespace Passbook.Generator;
+
+public class SemanticTags : List<SemanticTag>
 {
-    public class SemanticTags : List<SemanticTag>
+    public void Write(Utf8JsonWriter writer)
     {
-        public void Write(JsonWriter writer)
+        writer.WritePropertyName("semantics");
+        writer.WriteStartObject();
+        
+        foreach (var tag in this)
         {
-            writer.WritePropertyName("semantics");
-            writer.WriteStartObject();
-            
-            foreach (var tag in this)
-            {
-                tag.Write(writer);
-            }
-
-            writer.WriteEndObject();
+            tag.Write(writer);
         }
+
+        writer.WriteEndObject();
     }
 }

--- a/Passbook.Generator/StandardField.cs
+++ b/Passbook.Generator/StandardField.cs
@@ -1,46 +1,46 @@
-﻿using Passbook.Generator.Exceptions;
+﻿using System.Text.Json;
+using Passbook.Generator.Exceptions;
 
-namespace Passbook.Generator.Fields
+namespace Passbook.Generator.Fields;
+
+public class StandardField : Field
 {
-    public class StandardField : Field
+    public StandardField()
+        : base()
+    { }
+
+    public StandardField(string key, string label, string value)
+        : base(key, label)
     {
-        public StandardField()
-            : base()
-        { }
+        Value = value;
+    }
 
-        public StandardField(string key, string label, string value)
-            : base(key, label)
+    public StandardField(string key, string label, string value, string attributedValue, DataDetectorTypes dataDetectorTypes)
+        : this(key, label, value)
+    {
+        AttributedValue = attributedValue;
+        DataDetectorTypes = dataDetectorTypes;
+    }
+
+    public string Value { get; set; }
+
+    protected override void WriteValue(Utf8JsonWriter writer)
+    {
+        if (Value == null)
         {
-            this.Value = value;
+            throw new RequiredFieldValueMissingException(Key);
         }
 
-        public StandardField(string key, string label, string value, string attributedValue, DataDetectorTypes dataDetectorTypes)
-            : this(key, label, value)
-        {
-            this.AttributedValue = attributedValue;
-            this.DataDetectorTypes = dataDetectorTypes;
-        }
+        writer.WriteStringValue(Value);
+    }
 
-        public string Value { get; set; }
+    public override void SetValue(object value)
+    {
+        Value = value as string;
+    }
 
-        protected override void WriteValue(Newtonsoft.Json.JsonWriter writer)
-        {
-            if (Value == null)
-            {
-                throw new RequiredFieldValueMissingException(Key);
-            }
-
-            writer.WriteValue(Value);
-        }
-
-        public override void SetValue(object value)
-        {
-            this.Value = value as string;
-        }
-
-        public override bool HasValue
-        {
-            get { return !string.IsNullOrEmpty(Value); }
-        }
+    public override bool HasValue
+    {
+        get { return !string.IsNullOrEmpty(Value); }
     }
 }

--- a/Passbook.Generator/Tags/AirlineCode.cs
+++ b/Passbook.Generator/Tags/AirlineCode.cs
@@ -1,15 +1,8 @@
-﻿using Newtonsoft.Json;
+﻿namespace Passbook.Generator.Tags;
 
-namespace Passbook.Generator.Tags
+/// <summary>
+/// The IATA airline code, such as “EX” for flightCode “EX123”. Use this key only for airline boarding passes.
+/// </summary>
+public class AirlineCode(string value) : SemanticTagBaseValue("airlineCode", value)
 {
-    /// <summary>
-    /// The IATA airline code, such as “EX” for flightCode “EX123”. Use this key only for airline boarding passes.
-    /// </summary>
-    public class AirlineCode : SemanticTagBaseValue
-    {
-        public AirlineCode(string value) : base("airlineCode", value)
-        {
-            // NO Op
-        }
-    }
 }

--- a/Passbook.Generator/Tags/ArtistIds.cs
+++ b/Passbook.Generator/Tags/ArtistIds.cs
@@ -1,23 +1,21 @@
-﻿using Newtonsoft.Json;
+﻿using System.Text.Json;
 
-namespace Passbook.Generator.Tags
+namespace Passbook.Generator.Tags;
+
+/// <summary>
+/// An array of the Apple Music persistent ID for each artist performing at the event, in decreasing order of significance. 
+/// Use this key for any type of event ticket.
+/// </summary>
+public class ArtistIds(params string[] artistIds) : SemanticTag("artistIds")
 {
-    /// <summary>
-    /// An array of the Apple Music persistent ID for each artist performing at the event, in decreasing order of significance. 
-    /// Use this key for any type of event ticket.
-    /// </summary>
-    public class ArtistIds : SemanticTag
+
+    public override void WriteValue(Utf8JsonWriter writer)
     {
-        private readonly string[] _artistIds;
-
-        public ArtistIds(params string[] artistIds) : base("artistIds")
+        writer.WriteStartArray();
+        foreach (var artistId in artistIds)
         {
-            _artistIds = artistIds;
+            writer.WriteStringValue(artistId);
         }
-
-        public override void WriteValue(JsonWriter writer)
-        {
-            writer.WriteValue(_artistIds);
-        }
+        writer.WriteEndArray();
     }
 }

--- a/Passbook.Generator/Tags/AwayTeamAbbreviation.cs
+++ b/Passbook.Generator/Tags/AwayTeamAbbreviation.cs
@@ -1,13 +1,8 @@
-﻿namespace Passbook.Generator.Tags
+﻿namespace Passbook.Generator.Tags;
+
+/// <summary>
+/// The unique abbreviation of the away team’s name. Use this key only for a sports event ticket.
+/// </summary>
+public class AwayTeamAbbreviation(string value) : SemanticTagBaseValue("awayTeamAbbreviation", value)
 {
-    /// <summary>
-    /// The unique abbreviation of the away team’s name. Use this key only for a sports event ticket.
-    /// </summary>
-    public class AwayTeamAbbreviation : SemanticTagBaseValue
-    {
-        public AwayTeamAbbreviation(string value) : base("awayTeamAbbreviation", value)
-        {
-            // NO OP
-        }
-    }
 }

--- a/Passbook.Generator/Tags/AwayTeamLocation.cs
+++ b/Passbook.Generator/Tags/AwayTeamLocation.cs
@@ -1,13 +1,8 @@
-﻿namespace Passbook.Generator.Tags
+﻿namespace Passbook.Generator.Tags;
+
+/// <summary>
+/// The home location of the away team. Use this key only for a sports event ticket.
+/// </summary>
+public class AwayTeamLocation(string value) : SemanticTagBaseValue("awayTeamLocation", value)
 {
-    /// <summary>
-    /// The home location of the away team. Use this key only for a sports event ticket.
-    /// </summary>
-    public class AwayTeamLocation : SemanticTagBaseValue
-    {
-        public AwayTeamLocation(string value) : base("awayTeamLocation", value)
-        {
-            // NO OP
-        }
-    }
 }

--- a/Passbook.Generator/Tags/AwayTeamName.cs
+++ b/Passbook.Generator/Tags/AwayTeamName.cs
@@ -1,13 +1,8 @@
-﻿namespace Passbook.Generator.Tags
+﻿namespace Passbook.Generator.Tags;
+
+/// <summary>
+/// The name of the away team. Use this key only for a sports event ticket.
+/// </summary>
+public class AwayTeamName(string value) : SemanticTagBaseValue("awayTeamName", value)
 {
-    /// <summary>
-    /// The name of the away team. Use this key only for a sports event ticket.
-    /// </summary>
-    public class AwayTeamName : SemanticTagBaseValue
-    {
-        public AwayTeamName(string value) : base("awayTeamName", value)
-        {
-            // NO OP
-        }
-    }
 }

--- a/Passbook.Generator/Tags/EventTypes.cs
+++ b/Passbook.Generator/Tags/EventTypes.cs
@@ -1,14 +1,13 @@
-﻿namespace Passbook.Generator.Tags
+﻿namespace Passbook.Generator.Tags;
+
+public enum EventTypes
 {
-    public enum EventTypes
-    {
-        PKEventTypeGeneric,
-        PKEventTypeLivePerformance,
-        PKEventTypeMovie,
-        PKEventTypeSports,
-        PKEventTypeConference,
-        PKEventTypeConvention,
-        PKEventTypeWorkshop,
-        PKEventTypeSocialGathering
-    }
+    PKEventTypeGeneric,
+    PKEventTypeLivePerformance,
+    PKEventTypeMovie,
+    PKEventTypeSports,
+    PKEventTypeConference,
+    PKEventTypeConvention,
+    PKEventTypeWorkshop,
+    PKEventTypeSocialGathering
 }

--- a/Passbook.Generator/Tags/Seat.cs
+++ b/Passbook.Generator/Tags/Seat.cs
@@ -1,39 +1,38 @@
-﻿namespace Passbook.Generator.Tags
+﻿namespace Passbook.Generator.Tags;
+
+public class Seat
 {
-    public class Seat
-    {
-        /// <summary>
-        /// A description of the seat, such as “A flat bed seat”.
-        /// </summary>
-        public string SeatDescription { get; set; }
+    /// <summary>
+    /// A description of the seat, such as “A flat bed seat”.
+    /// </summary>
+    public string SeatDescription { get; set; }
 
-        /// <summary>
-        /// The identifier code for the seat.
-        /// </summary>
+    /// <summary>
+    /// The identifier code for the seat.
+    /// </summary>
 
-        public string SeatIdentifier { get; set; }
+    public string SeatIdentifier { get; set; }
 
 
-        /// <summary>
-        /// The number of the seat.
-        /// </summary>
-        public string SeatNumber { get; set; }
+    /// <summary>
+    /// The number of the seat.
+    /// </summary>
+    public string SeatNumber { get; set; }
 
 
-        /// <summary>
-        /// The row that contains the seat.
-        /// </summary>
-        public string SeatRow { get; set; }
+    /// <summary>
+    /// The row that contains the seat.
+    /// </summary>
+    public string SeatRow { get; set; }
 
-        /// <summary>
-        /// The section that contains the seat.
-        /// </summary>
+    /// <summary>
+    /// The section that contains the seat.
+    /// </summary>
 
-        public string SeatSection { get; set; }
+    public string SeatSection { get; set; }
 
-        /// <summary>
-        /// The type of seat, such as “Reserved seating”.
-        /// </summary>
-        public string SeatType { get; set; }
-    }
+    /// <summary>
+    /// The type of seat, such as “Reserved seating”.
+    /// </summary>
+    public string SeatType { get; set; }
 }

--- a/Passbook.Generator/Tags/SemanticTag.cs
+++ b/Passbook.Generator/Tags/SemanticTag.cs
@@ -1,22 +1,16 @@
-﻿using Newtonsoft.Json;
+﻿using System.Text.Json;
 
-namespace Passbook.Generator.Tags
+namespace Passbook.Generator.Tags;
+
+public abstract class SemanticTag(string tag)
 {
-    public abstract class SemanticTag
+    public string Tag { get; } = tag;
+
+    public void Write(Utf8JsonWriter writer)
     {
-        public SemanticTag(string tag)
-        {
-            Tag = tag;
-        }
-
-        public string Tag { get; }
-
-        public void Write(JsonWriter writer)
-        {
-            writer.WritePropertyName(Tag);
-            WriteValue(writer);
-        }
-
-        public abstract void WriteValue(JsonWriter writer);
+        writer.WritePropertyName(Tag);
+        WriteValue(writer);
     }
+
+    public abstract void WriteValue(Utf8JsonWriter writer);
 }

--- a/Passbook.Generator/Tags/SemanticTagBaseValue.cs
+++ b/Passbook.Generator/Tags/SemanticTagBaseValue.cs
@@ -1,29 +1,52 @@
-﻿using Newtonsoft.Json;
+﻿using System;
+using System.Text.Json;
 
-namespace Passbook.Generator.Tags
+namespace Passbook.Generator.Tags;
+
+public abstract class SemanticTagBaseValue : SemanticTag
 {
-    public abstract class SemanticTagBaseValue : SemanticTag
+    private readonly object _value;
+
+    public SemanticTagBaseValue(string tag, string value) : base(tag)
     {
-        private readonly object _value;
+        _value = value;
+    }
 
-        public SemanticTagBaseValue(string tag, string value) : base(tag)
-        {
-            _value = value;
-        }
+    public SemanticTagBaseValue(string tag, bool value) : base(tag)
+    {
+        _value = value;
+    }
 
-        public SemanticTagBaseValue(string tag, bool value) : base(tag)
-        {
-            _value = value;
-        }
+    public SemanticTagBaseValue(string tag, double value) : base(tag)
+    {
+        _value = value;
+    }
 
-        public SemanticTagBaseValue(string tag, double value) : base(tag)
+    public override void WriteValue(Utf8JsonWriter writer)
+    {
+        switch (_value)
         {
-            _value = value;
-        }
-
-        public override void WriteValue(JsonWriter writer)
-        {
-            writer.WriteValue(_value);
+            case string s:
+                writer.WriteStringValue(s);
+                break;
+            case bool b:
+                writer.WriteBooleanValue(b);
+                break;
+            case double d:
+                writer.WriteNumberValue(d);
+                break;
+            case float f:
+                writer.WriteNumberValue(f);
+                break;
+            case decimal m:
+                writer.WriteNumberValue(m);
+                break;
+            case int i:
+                writer.WriteNumberValue(i);
+                break;
+            case long l:
+                writer.WriteNumberValue(l);
+                break;
         }
     }
 }

--- a/Passbook.Generator/Tags/balance.cs
+++ b/Passbook.Generator/Tags/balance.cs
@@ -1,25 +1,16 @@
-﻿using Newtonsoft.Json;
+﻿using System.Text.Json;
 
 namespace Passbook.Generator.Tags
 {
-    public class Balance : SemanticTag
+    public class Balance(string amount, string currencyCode) : SemanticTag("balance")
     {
-        private readonly string _amount;
-        private readonly string _currencyCode;
-
-        public Balance(string amount, string currencyCode) : base("balance")
-        {
-            _amount = amount;
-            _currencyCode = currencyCode;
-        }
-
-        public override void WriteValue(JsonWriter writer)
+        public override void WriteValue(Utf8JsonWriter writer)
         {
             writer.WriteStartObject();
             writer.WritePropertyName("amount");
-            writer.WriteValue(_amount);
+            writer.WriteStringValue(amount);
             writer.WritePropertyName("currencyCode");
-            writer.WriteValue(_currencyCode);
+            writer.WriteStringValue(currencyCode);
             writer.WriteEndObject();
         }
     }

--- a/Passbook.Generator/Tags/boardingGroup.cs
+++ b/Passbook.Generator/Tags/boardingGroup.cs
@@ -1,10 +1,5 @@
-﻿namespace Passbook.Generator.Tags
+﻿namespace Passbook.Generator.Tags;
+
+public class BoardingGroup(string value) : SemanticTagBaseValue("boardingGroup", value)
 {
-    public class BoardingGroup : SemanticTagBaseValue
-    {
-        public BoardingGroup(string value) : base("boardingGroup", value)
-        {
-            // NO OP
-        }
-    }
 }

--- a/Passbook.Generator/Tags/boardingSequenceNumber.cs
+++ b/Passbook.Generator/Tags/boardingSequenceNumber.cs
@@ -1,9 +1,5 @@
-﻿namespace Passbook.Generator.Tags
+﻿namespace Passbook.Generator.Tags;
+
+public class BoardingSequenceNumber(string value) : SemanticTagBaseValue("boardingSequenceNumber", value)
 {
-    public class BoardingSequenceNumber : SemanticTagBaseValue
-    {
-        public BoardingSequenceNumber(string value) : base("boardingSequenceNumber", value)
-        {
-        }
-    }
 }

--- a/Passbook.Generator/Tags/carNumber.cs
+++ b/Passbook.Generator/Tags/carNumber.cs
@@ -1,10 +1,5 @@
-﻿namespace Passbook.Generator.Tags
+﻿namespace Passbook.Generator.Tags;
+
+public class CarNumber(string value) : SemanticTagBaseValue("carNumber", value)
 {
-    public class CarNumber : SemanticTagBaseValue
-    {
-        public CarNumber(string value) : base("carNumber", value)
-        {
-            // NO OP
-        }
-    }
 }

--- a/Passbook.Generator/Tags/confirmationNumber.cs
+++ b/Passbook.Generator/Tags/confirmationNumber.cs
@@ -1,10 +1,5 @@
-﻿namespace Passbook.Generator.Tags
+﻿namespace Passbook.Generator.Tags;
+
+public class ConfirmationNumber(string value) : SemanticTagBaseValue("confirmationNumber", value)
 {
-    public class ConfirmationNumber : SemanticTagBaseValue
-    {
-        public ConfirmationNumber(string value) : base("confirmationNumber", value)
-        {
-            // NO OP
-        }
-    }
 }

--- a/Passbook.Generator/Tags/currentArrivalDate.cs
+++ b/Passbook.Generator/Tags/currentArrivalDate.cs
@@ -1,10 +1,5 @@
-﻿namespace Passbook.Generator.Tags
+﻿namespace Passbook.Generator.Tags;
+
+public class CurrentArrivalDate(string value) : SemanticTagBaseValue("currentArrivalDate", value)
 {
-    public class CurrentArrivalDate : SemanticTagBaseValue
-    {
-        public CurrentArrivalDate(string value) : base("currentArrivalDate", value)
-        {
-            // NO OP
-        }
-    }
 }

--- a/Passbook.Generator/Tags/currentBoardingDate.cs
+++ b/Passbook.Generator/Tags/currentBoardingDate.cs
@@ -1,10 +1,5 @@
-﻿namespace Passbook.Generator.Tags
+﻿namespace Passbook.Generator.Tags;
+
+class CurrentBoardingDate(string value) : SemanticTagBaseValue("currentBoardingDate", value)
 {
-    class CurrentBoardingDate : SemanticTagBaseValue
-    {
-        public CurrentBoardingDate(string value) : base("currentBoardingDate", value)
-        {
-            // NO OP
-        }
-    }
 }

--- a/Passbook.Generator/Tags/currentDepartureDate.cs
+++ b/Passbook.Generator/Tags/currentDepartureDate.cs
@@ -1,10 +1,5 @@
-﻿namespace Passbook.Generator.Tags
+﻿namespace Passbook.Generator.Tags;
+
+class CurrentDepartureDate(string value) : SemanticTagBaseValue("currentDepartureDate", value)
 {
-    class CurrentDepartureDate : SemanticTagBaseValue
-    {
-        public CurrentDepartureDate(string value) : base("currentDepartureDate", value)
-        {
-            // NO OP
-        }
-    }
 }

--- a/Passbook.Generator/Tags/departureAirportCode.cs
+++ b/Passbook.Generator/Tags/departureAirportCode.cs
@@ -1,10 +1,5 @@
-﻿namespace Passbook.Generator.Tags
+﻿namespace Passbook.Generator.Tags;
+
+class DepartureAirportCode(string value) : SemanticTagBaseValue("departureAirportCode", value)
 {
-    class DepartureAirportCode : SemanticTagBaseValue
-    {
-        public DepartureAirportCode(string value) : base("departureAirportCode", value)
-        {
-            // NO OP
-        }
-    }
 }

--- a/Passbook.Generator/Tags/departureAirportName.cs
+++ b/Passbook.Generator/Tags/departureAirportName.cs
@@ -1,10 +1,5 @@
-﻿namespace Passbook.Generator.Tags
+﻿namespace Passbook.Generator.Tags;
+
+class DepartureAirportName(string value) : SemanticTagBaseValue("departureAirportName", value)
 {
-    class DepartureAirportName : SemanticTagBaseValue
-    {
-        public DepartureAirportName(string value) : base("departureAirportName", value)
-        {
-            // NO OP
-        }
-    }
 }

--- a/Passbook.Generator/Tags/departureGate.cs
+++ b/Passbook.Generator/Tags/departureGate.cs
@@ -1,10 +1,5 @@
-﻿namespace Passbook.Generator.Tags
+﻿namespace Passbook.Generator.Tags;
+
+class DepartureGate(string value) : SemanticTagBaseValue("departureGate", value)
 {
-    class DepartureGate : SemanticTagBaseValue
-    {
-        public DepartureGate(string value) : base("departureGate", value)
-        {
-            // NO OP
-        }
-    }
 }

--- a/Passbook.Generator/Tags/departureLocation.cs
+++ b/Passbook.Generator/Tags/departureLocation.cs
@@ -1,25 +1,16 @@
-﻿using Newtonsoft.Json;
+﻿using System.Text.Json;
 
 namespace Passbook.Generator.Tags
 {
-    public class DepartureLocation : SemanticTag
+    public class DepartureLocation(double latitude, double longitude) : SemanticTag("departureLocation")
     {
-        private readonly double _latitude;
-        private readonly double _longitude;
-
-        public DepartureLocation(double latitude, double longitude) : base("departureLocation")
-        {
-            _latitude = latitude;
-            _longitude = longitude;
-        }
-
-        public override void WriteValue(JsonWriter writer)
+        public override void WriteValue(Utf8JsonWriter writer)
         {
             writer.WriteStartObject();
             writer.WritePropertyName("latitude");
-            writer.WriteValue(_latitude);
+            writer.WriteNumberValue(latitude);
             writer.WritePropertyName("longitude");
-            writer.WriteValue(_longitude);
+            writer.WriteNumberValue(longitude);
             writer.WriteEndObject();
         }
     }

--- a/Passbook.Generator/Tags/departureLocationDescription.cs
+++ b/Passbook.Generator/Tags/departureLocationDescription.cs
@@ -1,10 +1,6 @@
 ﻿namespace Passbook.Generator.Tags
 {
-    class DepartureLocationDescription : SemanticTagBaseValue
+    class DepartureLocationDescription(string value) : SemanticTagBaseValue("departureLocationDescription", value)
     {
-        public DepartureLocationDescription(string value) : base("departureLocationDescription", value)
-        {
-            // NO OP
-        }
     }
 }

--- a/Passbook.Generator/Tags/departurePlatform.cs
+++ b/Passbook.Generator/Tags/departurePlatform.cs
@@ -1,10 +1,6 @@
 ﻿namespace Passbook.Generator.Tags
 {
-    public class DeparturePlatform : SemanticTagBaseValue
+    public class DeparturePlatform(string value) : SemanticTagBaseValue("departurePlatform", value)
     {
-        public DeparturePlatform(string value) : base("departurePlatform", value)
-        {
-            // NO OP
-        }
     }
 }

--- a/Passbook.Generator/Tags/departureStationName.cs
+++ b/Passbook.Generator/Tags/departureStationName.cs
@@ -1,10 +1,5 @@
-﻿namespace Passbook.Generator.Tags
+﻿namespace Passbook.Generator.Tags;
+
+public class DepartureStationName(string value) : SemanticTagBaseValue("departureStationName", value)
 {
-    public class DepartureStationName : SemanticTagBaseValue
-    {
-        public DepartureStationName(string value) : base("departureStationName", value)
-        {
-            // NO OP
-        }
-    }
 }

--- a/Passbook.Generator/Tags/departureTerminal.cs
+++ b/Passbook.Generator/Tags/departureTerminal.cs
@@ -1,10 +1,5 @@
-﻿namespace Passbook.Generator.Tags
+﻿namespace Passbook.Generator.Tags;
+
+public class DepartureTerminal(string value) : SemanticTagBaseValue("departureTerminal", value)
 {
-    public class DepartureTerminal : SemanticTagBaseValue
-    {
-        public DepartureTerminal(string value) : base("departureTerminal", value)
-        {
-            // NO OP
-        }
-    }
 }

--- a/Passbook.Generator/Tags/destinationAirportCode.cs
+++ b/Passbook.Generator/Tags/destinationAirportCode.cs
@@ -1,10 +1,5 @@
-﻿namespace Passbook.Generator.Tags
+﻿namespace Passbook.Generator.Tags;
+
+class DestinationAirportCode(string value) : SemanticTagBaseValue("destinationAirportCode", value)
 {
-    class DestinationAirportCode : SemanticTagBaseValue
-    {
-        public DestinationAirportCode(string value) : base("destinationAirportCode", value)
-        {
-            // NO OP
-        }
-    }
 }

--- a/Passbook.Generator/Tags/destinationAirportName.cs
+++ b/Passbook.Generator/Tags/destinationAirportName.cs
@@ -1,10 +1,5 @@
-﻿namespace Passbook.Generator.Tags
+﻿namespace Passbook.Generator.Tags;
+
+public class DestinationAirportName(string value) : SemanticTagBaseValue("destinationAirportName", value)
 {
-    public class DestinationAirportName : SemanticTagBaseValue
-    {
-        public DestinationAirportName(string value) : base("destinationAirportName", value)
-        {
-            // NO OP
-        }
-    }
 }

--- a/Passbook.Generator/Tags/destinationGate.cs
+++ b/Passbook.Generator/Tags/destinationGate.cs
@@ -1,10 +1,5 @@
-﻿namespace Passbook.Generator.Tags
+﻿namespace Passbook.Generator.Tags;
+
+public class DestinationGate(string value) : SemanticTagBaseValue("destinationGate", value)
 {
-    public class DestinationGate : SemanticTagBaseValue
-    {
-        public DestinationGate(string value) : base("destinationGate", value)
-        {
-            // NO OP
-        }
-    }
 }

--- a/Passbook.Generator/Tags/destinationLocation.cs
+++ b/Passbook.Generator/Tags/destinationLocation.cs
@@ -1,26 +1,15 @@
-﻿using Newtonsoft.Json;
+﻿using System.Text.Json;
 
-namespace Passbook.Generator.Tags
-{
-    public class DestinationLocation : SemanticTag
+namespace Passbook.Generator.Tags;
+
+public class DestinationLocation(double latitude, double longitude) : SemanticTag("destinationLocation ")
+{    public override void WriteValue(Utf8JsonWriter writer)
     {
-        private readonly double _latitude;
-        private readonly double _longitude;
-
-        public DestinationLocation(double latitude, double longitude) : base("destinationLocation ")
-        {
-            _latitude = latitude;
-            _longitude = longitude;
-        }
-
-        public override void WriteValue(JsonWriter writer)
-        {
-            writer.WriteStartObject();
-            writer.WritePropertyName("latitude");
-            writer.WriteValue(_latitude);
-            writer.WritePropertyName("longitude");
-            writer.WriteValue(_longitude);
-            writer.WriteEndObject();
-        }
+        writer.WriteStartObject();
+        writer.WritePropertyName("latitude");
+        writer.WriteNumberValue(latitude);
+        writer.WritePropertyName("longitude");
+        writer.WriteNumberValue(longitude);
+        writer.WriteEndObject();
     }
 }

--- a/Passbook.Generator/Tags/destinationLocationDescription.cs
+++ b/Passbook.Generator/Tags/destinationLocationDescription.cs
@@ -1,10 +1,5 @@
-﻿namespace Passbook.Generator.Tags
+﻿namespace Passbook.Generator.Tags;
+
+public class DestinationLocationDescription(string value) : SemanticTagBaseValue("destinationLocationDescription", value)
 {
-    public class DestinationLocationDescription : SemanticTagBaseValue
-    {
-        public DestinationLocationDescription(string value) : base("destinationLocationDescription", value)
-        {
-            // NO OP
-        }
-    }
 }

--- a/Passbook.Generator/Tags/destinationPlatform.cs
+++ b/Passbook.Generator/Tags/destinationPlatform.cs
@@ -1,10 +1,5 @@
-﻿namespace Passbook.Generator.Tags
+﻿namespace Passbook.Generator.Tags;
+
+public class DestinationPlatform(string value) : SemanticTagBaseValue("destinationPlatform", value)
 {
-    public class DestinationPlatform : SemanticTagBaseValue
-    {
-        public DestinationPlatform(string value) : base("destinationPlatform", value)
-        {
-            // NO OP
-        }
-    }
 }

--- a/Passbook.Generator/Tags/destinationStationName.cs
+++ b/Passbook.Generator/Tags/destinationStationName.cs
@@ -1,10 +1,5 @@
-﻿namespace Passbook.Generator.Tags
+﻿namespace Passbook.Generator.Tags;
+
+class DestinationStationName(string value) : SemanticTagBaseValue("destinationStationName", value)
 {
-    class DestinationStationName : SemanticTagBaseValue
-    {
-        public DestinationStationName(string value) : base("destinationStationName", value)
-        {
-            // NO OP
-        }
-    }
 }

--- a/Passbook.Generator/Tags/destinationTerminal.cs
+++ b/Passbook.Generator/Tags/destinationTerminal.cs
@@ -1,10 +1,5 @@
-﻿namespace Passbook.Generator.Tags
+﻿namespace Passbook.Generator.Tags;
+
+public class DestinationTerminal(string value) : SemanticTagBaseValue("destinationTerminal", value)
 {
-    public class DestinationTerminal : SemanticTagBaseValue
-    {
-        public DestinationTerminal(string value) : base("destinationTerminal", value)
-        {
-            // NO OP
-        }
-    }
 }

--- a/Passbook.Generator/Tags/duration.cs
+++ b/Passbook.Generator/Tags/duration.cs
@@ -1,12 +1,6 @@
-﻿using Newtonsoft.Json;
-
-namespace Passbook.Generator.Tags
+﻿namespace Passbook.Generator.Tags
 {
-    public class Duration : SemanticTagBaseValue
+    public class Duration(double value) : SemanticTagBaseValue("duration", value)
     {
-        public Duration(double value) : base("duration", value)
-        {
-            // NO OP
-        }
     }
 }

--- a/Passbook.Generator/Tags/eventEndDate.cs
+++ b/Passbook.Generator/Tags/eventEndDate.cs
@@ -1,14 +1,9 @@
-﻿namespace Passbook.Generator.Tags
+﻿namespace Passbook.Generator.Tags;
+
+/// <summary>
+/// The date and time the event ends. Use this key for any type of event ticket.
+/// </summary>
+/// <param name="value">ISO 8601 date as string</param>
+public class EventEndDate(string value) : SemanticTagBaseValue("eventEndDate", value)
 {
-    /// <summary>
-    /// The date and time the event ends. Use this key for any type of event ticket.
-    /// </summary>
-    public class EventEndDate : SemanticTagBaseValue
-    {
-        /// <param name="value">ISO 8601 date as string</param>
-        public EventEndDate(string value) : base("eventEndDate", value)
-        {
-            // NO OP
-        }
-    }
 }

--- a/Passbook.Generator/Tags/eventName.cs
+++ b/Passbook.Generator/Tags/eventName.cs
@@ -1,13 +1,8 @@
-﻿namespace Passbook.Generator.Tags
+﻿namespace Passbook.Generator.Tags;
+
+/// <summary>
+/// The full name of the event, such as the title of a movie. Use this key for any type of event ticket.
+/// </summary>
+public class EventName(string value) : SemanticTagBaseValue("eventName", value)
 {
-    /// <summary>
-    /// The full name of the event, such as the title of a movie. Use this key for any type of event ticket.
-    /// </summary>
-    public class EventName : SemanticTagBaseValue
-    {
-        public EventName(string value) : base("eventName", value)
-        {
-            // NO OP
-        }
-    }
 }

--- a/Passbook.Generator/Tags/eventStartDate.cs
+++ b/Passbook.Generator/Tags/eventStartDate.cs
@@ -1,14 +1,9 @@
-﻿namespace Passbook.Generator.Tags
+﻿namespace Passbook.Generator.Tags;
+
+/// <summary>
+/// The date and time the event starts. Use this key for any type of event ticket.
+/// </summary>
+/// <param name="value">ISO 8601 date as string</param>
+public class EventStartDate(string value) : SemanticTagBaseValue("eventStartDate", value)
 {
-    /// <summary>
-    /// The date and time the event starts. Use this key for any type of event ticket.
-    /// </summary>
-    public class EventStartDate : SemanticTagBaseValue
-    {
-        /// <param name="value">ISO 8601 date as string</param>
-        public EventStartDate(string value) : base("eventStartDate", value)
-        {
-            // NO OP
-        }
-    }
 }

--- a/Passbook.Generator/Tags/eventType.cs
+++ b/Passbook.Generator/Tags/eventType.cs
@@ -1,22 +1,14 @@
-﻿using Newtonsoft.Json;
+﻿using System.Text.Json;
 
-namespace Passbook.Generator.Tags
+namespace Passbook.Generator.Tags;
+
+/// <summary>
+/// The type of event. Use this key for any type of event ticket.
+/// </summary>
+public class EventType(EventTypes eventType) : SemanticTag("eventType")
 {
-    /// <summary>
-    /// The type of event. Use this key for any type of event ticket.
-    /// </summary>
-    public class EventType : SemanticTag
+    public override void WriteValue(Utf8JsonWriter writer)
     {
-        private readonly EventTypes _eventType;
-
-        public EventType(EventTypes eventType) : base("eventType")
-        {
-            _eventType = eventType;
-        }
-
-        public override void WriteValue(JsonWriter writer)
-        {
-            writer.WriteValue(_eventType.ToString());
-        }
+        writer.WriteStringValue(eventType.ToString());
     }
 }

--- a/Passbook.Generator/Tags/flightCode.cs
+++ b/Passbook.Generator/Tags/flightCode.cs
@@ -1,14 +1,9 @@
-﻿namespace Passbook.Generator.Tags
+﻿namespace Passbook.Generator.Tags;
+
+/// <summary>
+/// The IATA flight code, such as “EX123”. Use this key only for airline boarding passes.
+/// </summary>
+/// <param name="value"></param>
+public class FlightCode(string value) : SemanticTagBaseValue("flightCode", value)
 {
-    public class FlightCode : SemanticTagBaseValue
-    {
-        /// <summary>
-        /// The IATA flight code, such as “EX123”. Use this key only for airline boarding passes.
-        /// </summary>
-        /// <param name="value"></param>
-        public FlightCode(string value) : base("flightCode", value)
-        {
-            // NO OP
-        }
-    }
 }

--- a/Passbook.Generator/Tags/flightNumber.cs
+++ b/Passbook.Generator/Tags/flightNumber.cs
@@ -1,13 +1,8 @@
-﻿namespace Passbook.Generator.Tags
+﻿namespace Passbook.Generator.Tags;
+
+/// <summary>
+/// The numeric portion of the IATA flight code, such as 123 for flightCode “EX123”. Use this key only for airline boarding passes.
+/// </summary>
+public class FlightNumber(string value) : SemanticTagBaseValue("flightNumber", value)
 {
-    /// <summary>
-    /// The numeric portion of the IATA flight code, such as 123 for flightCode “EX123”. Use this key only for airline boarding passes.
-    /// </summary>
-    public class FlightNumber : SemanticTagBaseValue
-    {
-        public FlightNumber(string value) : base("flightNumber", value)
-        {
-            // NO OP
-        }
-    }
 }

--- a/Passbook.Generator/Tags/genre.cs
+++ b/Passbook.Generator/Tags/genre.cs
@@ -1,13 +1,8 @@
-﻿namespace Passbook.Generator.Tags
+﻿namespace Passbook.Generator.Tags;
+
+/// <summary>
+/// The genre of the performance, such as “Classical”. Use this key for any type of event ticket.
+/// </summary>
+public class Genre(string value) : SemanticTagBaseValue("genre", value)
 {
-    /// <summary>
-    /// The genre of the performance, such as “Classical”. Use this key for any type of event ticket.
-    /// </summary>
-    public class Genre : SemanticTagBaseValue
-    {
-        public Genre(string value) : base("genre", value)
-        {
-            // NO OP
-        }
-    }
 }

--- a/Passbook.Generator/Tags/homeTeamAbbreviation.cs
+++ b/Passbook.Generator/Tags/homeTeamAbbreviation.cs
@@ -1,13 +1,8 @@
-﻿namespace Passbook.Generator.Tags
+﻿namespace Passbook.Generator.Tags;
+
+/// <summary>
+/// The unique abbreviation of the homee team’s name. Use this key only for a sports event ticket.
+/// </summary>
+public class HomeTeamAbbreviation(string value) : SemanticTagBaseValue("homeTeamAbbreviation", value)
 {
-    /// <summary>
-    /// The unique abbreviation of the homee team’s name. Use this key only for a sports event ticket.
-    /// </summary>
-    public class HomeTeamAbbreviation : SemanticTagBaseValue
-    {
-        public HomeTeamAbbreviation(string value) : base("homeTeamAbbreviation", value)
-        {
-            // NO OP
-        }
-    }
 }

--- a/Passbook.Generator/Tags/homeTeamLocation.cs
+++ b/Passbook.Generator/Tags/homeTeamLocation.cs
@@ -1,13 +1,8 @@
-﻿namespace Passbook.Generator.Tags
+﻿namespace Passbook.Generator.Tags;
+
+/// <summary>
+/// The home location of the home team. Use this key only for a sports event ticket.
+/// </summary>
+public class HomeTeamLocation(string value) : SemanticTagBaseValue("homeTeamLocation", value)
 {
-    /// <summary>
-    /// The home location of the home team. Use this key only for a sports event ticket.
-    /// </summary>
-    public class HomeTeamLocation : SemanticTagBaseValue
-    {
-        public HomeTeamLocation(string value) : base("homeTeamLocation", value)
-        {
-            // NO OP
-        }
-    }
 }

--- a/Passbook.Generator/Tags/homeTeamName.cs
+++ b/Passbook.Generator/Tags/homeTeamName.cs
@@ -1,13 +1,8 @@
-﻿namespace Passbook.Generator.Tags
+﻿namespace Passbook.Generator.Tags;
+
+/// <summary>
+/// The name of the home team. Use this key only for a sports event ticket.
+/// </summary>
+public class HomeTeamName(string value) : SemanticTagBaseValue("homeTeamName", value)
 {
-    /// <summary>
-    /// The name of the home team. Use this key only for a sports event ticket.
-    /// </summary>
-    public class HomeTeamName : SemanticTagBaseValue
-    {
-        public HomeTeamName(string value) : base("homeTeamName", value)
-        {
-            // NO OP
-        }
-    }
 }

--- a/Passbook.Generator/Tags/leagueAbbreviation.cs
+++ b/Passbook.Generator/Tags/leagueAbbreviation.cs
@@ -1,12 +1,8 @@
-﻿namespace Passbook.Generator.Tags
+﻿namespace Passbook.Generator.Tags;
+
+/// <summary>
+/// The abbreviated league name for a sports event. Use this key only for a sports event ticket.
+/// </summary>
+public class LeagueAbbreviation(string value) : SemanticTagBaseValue("leagueAbbreviation", value)
 {
-    /// <summary>
-    /// The abbreviated league name for a sports event. Use this key only for a sports event ticket.
-    /// </summary>
-    public class LeagueAbbreviation : SemanticTagBaseValue
-    {
-        public LeagueAbbreviation(string value) : base("leagueAbbreviation", value)
-        {
-        }
-    }
 }

--- a/Passbook.Generator/Tags/leagueName.cs
+++ b/Passbook.Generator/Tags/leagueName.cs
@@ -1,12 +1,8 @@
-﻿namespace Passbook.Generator.Tags
+﻿namespace Passbook.Generator.Tags;
+
+/// <summary>
+/// The unabbreviated league name for a sports event. Use this key only for a sports event ticket.
+/// </summary>
+public class LeagueName(string value) : SemanticTagBaseValue("leagueName", value)
 {
-    /// <summary>
-    /// The unabbreviated league name for a sports event. Use this key only for a sports event ticket.
-    /// </summary>
-    public class LeagueName : SemanticTagBaseValue
-    {
-        public LeagueName(string value) : base("leagueName", value)
-        {
-        }
-    }
 }

--- a/Passbook.Generator/Tags/membershipProgramName.cs
+++ b/Passbook.Generator/Tags/membershipProgramName.cs
@@ -1,12 +1,8 @@
-﻿namespace Passbook.Generator.Tags
+﻿namespace Passbook.Generator.Tags;
+
+/// <summary>
+/// The name of a frequent flyer or loyalty program. Use this key for any type of boarding pass.
+/// </summary>
+public class MembershipProgramName(string value) : SemanticTagBaseValue("membershipProgramName", value)
 {
-    /// <summary>
-    /// The name of a frequent flyer or loyalty program. Use this key for any type of boarding pass.
-    /// </summary>
-    public class MembershipProgramName : SemanticTagBaseValue
-    {
-        public MembershipProgramName(string value) : base("membershipProgramName", value)
-        {
-        }
-    }
 }

--- a/Passbook.Generator/Tags/membershipProgramNumber.cs
+++ b/Passbook.Generator/Tags/membershipProgramNumber.cs
@@ -1,13 +1,9 @@
-﻿namespace Passbook.Generator.Tags
+﻿namespace Passbook.Generator.Tags;
+
+/// <summary>
+/// The ticketed passenger’s frequent flyer or loyalty number. Use this key for any type of boarding pass.
+/// </summary>
+public class MembershipProgramNumber(string value) : SemanticTagBaseValue("membershipProgramNumber", value)
 {
-    /// <summary>
-    /// The ticketed passenger’s frequent flyer or loyalty number. Use this key for any type of boarding pass.
-    /// </summary>
-    public class MembershipProgramNumber : SemanticTagBaseValue
-    {
-        public MembershipProgramNumber(string value) : base("membershipProgramNumber", value)
-        {
-        }
-    }
 }
 

--- a/Passbook.Generator/Tags/originalArrivalDate.cs
+++ b/Passbook.Generator/Tags/originalArrivalDate.cs
@@ -1,10 +1,5 @@
-﻿namespace Passbook.Generator.Tags
+﻿namespace Passbook.Generator.Tags;
+
+public class OriginalArrivalDate(string value) : SemanticTagBaseValue("originalArrivalDate", value)
 {
-    public class OriginalArrivalDate : SemanticTagBaseValue
-    {
-        public OriginalArrivalDate(string value) : base("originalArrivalDate", value)
-        {
-            // NO OP
-        }
-    }
 }

--- a/Passbook.Generator/Tags/originalBoardingDate.cs
+++ b/Passbook.Generator/Tags/originalBoardingDate.cs
@@ -1,10 +1,5 @@
-﻿namespace Passbook.Generator.Tags
+﻿namespace Passbook.Generator.Tags;
+
+public class OriginalBoardingDate(string value) : SemanticTagBaseValue("originalBoardingDate", value)
 {
-    public class OriginalBoardingDate : SemanticTagBaseValue
-    {
-        public OriginalBoardingDate(string value) : base("originalBoardingDate", value)
-        {
-            // NO OP
-        }
-    }
 }

--- a/Passbook.Generator/Tags/originalDepartureDate.cs
+++ b/Passbook.Generator/Tags/originalDepartureDate.cs
@@ -1,10 +1,5 @@
-﻿namespace Passbook.Generator.Tags
+﻿namespace Passbook.Generator.Tags;
+
+public class OriginalDepartureDate(string value) : SemanticTagBaseValue("originalDepartureDate", value)
 {
-    public class OriginalDepartureDate : SemanticTagBaseValue
-    {
-        public OriginalDepartureDate(string value) : base("originalDepartureDate", value)
-        {
-            // NO OP
-        }
-    }
 }

--- a/Passbook.Generator/Tags/passengerName.cs
+++ b/Passbook.Generator/Tags/passengerName.cs
@@ -1,13 +1,8 @@
-﻿namespace Passbook.Generator.Tags
+﻿namespace Passbook.Generator.Tags;
+
+/// <summary>
+/// An object that represents the name of the passenger. Use this key for any type of boarding pass.
+/// </summary>
+public class PassengerName(string value) : SemanticTagBaseValue("passengerName", value)
 {
-    /// <summary>
-    /// An object that represents the name of the passenger. Use this key for any type of boarding pass.
-    /// </summary>
-    public class PassengerName : SemanticTagBaseValue
-    {
-        public PassengerName(string value) : base("passengerName", value)
-        {
-            // NO OP
-        }
-    }
 }

--- a/Passbook.Generator/Tags/performerNames.cs
+++ b/Passbook.Generator/Tags/performerNames.cs
@@ -1,22 +1,19 @@
-﻿using Newtonsoft.Json;
+﻿using System.Text.Json;
 
-namespace Passbook.Generator.Tags
+namespace Passbook.Generator.Tags;
+
+/// <summary>
+/// An array of the full names of the performers and opening acts at the event, in decreasing order of significance. Use this key for any type of event ticket.
+/// </summary>
+public class PerformerNames(params string[] performerNames) : SemanticTag("performerNames")
 {
-    /// <summary>
-    /// An array of the full names of the performers and opening acts at the event, in decreasing order of significance. Use this key for any type of event ticket.
-    /// </summary>
-    public class PerformerNames : SemanticTag
+    public override void WriteValue(Utf8JsonWriter writer)
     {
-        private readonly string[] _performerNames;
-
-        public PerformerNames(params string[] performerNames) : base("performerNames")
+        writer.WriteStartArray();
+        foreach (var performerName in performerNames)
         {
-            _performerNames = performerNames;
+            writer.WriteStringValue(performerName);
         }
-
-        public override void WriteValue(JsonWriter writer)
-        {
-            writer.WriteValue(_performerNames);
-        }
+        writer.WriteEndArray();
     }
 }

--- a/Passbook.Generator/Tags/priorityStatus.cs
+++ b/Passbook.Generator/Tags/priorityStatus.cs
@@ -1,13 +1,8 @@
-﻿namespace Passbook.Generator.Tags
+﻿namespace Passbook.Generator.Tags;
+
+/// <summary>
+/// The priority status the ticketed passenger holds, such as “Gold” or “Silver”. Use this key for any type of boarding pass.
+/// </summary>
+public class PriorityStatus(string value) : SemanticTagBaseValue("priorityStatus", value)
 {
-    /// <summary>
-    /// The priority status the ticketed passenger holds, such as “Gold” or “Silver”. Use this key for any type of boarding pass.
-    /// </summary>
-    public class PriorityStatus : SemanticTagBaseValue
-    {
-        public PriorityStatus(string value) : base("priorityStatus", value)
-        {
-            // NO OP
-        }
-    }
 }

--- a/Passbook.Generator/Tags/seats.cs
+++ b/Passbook.Generator/Tags/seats.cs
@@ -1,28 +1,20 @@
-﻿using Newtonsoft.Json;
+﻿using System.Text.Json;
 
-namespace Passbook.Generator.Tags
+namespace Passbook.Generator.Tags;
+
+public class Seats(params Seat[] seats) : SemanticTag("seats")
 {
-    public class Seats : SemanticTag
+    public override void WriteValue(Utf8JsonWriter writer)
     {
-        private readonly Seat[] _seats;
-
-        public Seats(params Seat[] seats) : base("seats")
+        writer.WriteStartArray();
+        
+        foreach(var seat in seats)
         {
-            _seats = seats;
+            writer.WriteStartObject();
+
+            writer.WriteEndObject();
         }
 
-        public override void WriteValue(JsonWriter writer)
-        {
-            writer.WriteStartArray();
-            
-            foreach(var seat in _seats)
-            {
-                writer.WriteStartObject();
-
-                writer.WriteEndObject();
-            }
-
-            writer.WriteEndArray();
-        }
+        writer.WriteEndArray();
     }
 }

--- a/Passbook.Generator/Tags/securityScreening.cs
+++ b/Passbook.Generator/Tags/securityScreening.cs
@@ -1,10 +1,5 @@
-﻿namespace Passbook.Generator.Tags
+﻿namespace Passbook.Generator.Tags;
+
+public class SecurityScreening(string value) : SemanticTagBaseValue("securityScreening", value)
 {
-    public class SecurityScreening : SemanticTagBaseValue
-    {
-        public SecurityScreening(string value) : base("securityScreening", value)
-        {
-            // NO OP
-        }
-    }
 }

--- a/Passbook.Generator/Tags/silenceRequested.cs
+++ b/Passbook.Generator/Tags/silenceRequested.cs
@@ -1,10 +1,5 @@
-﻿namespace Passbook.Generator.Tags
+﻿namespace Passbook.Generator.Tags;
+
+public class SilenceRequested(bool value) : SemanticTagBaseValue("silenceRequested", value)
 {
-    public class SilenceRequested : SemanticTagBaseValue
-    {
-        public SilenceRequested(bool value) : base("silenceRequested", value)
-        {
-            // NO OP
-        }
-    }
 }

--- a/Passbook.Generator/Tags/sportName.cs
+++ b/Passbook.Generator/Tags/sportName.cs
@@ -1,10 +1,5 @@
-﻿namespace Passbook.Generator.Tags
+﻿namespace Passbook.Generator.Tags;
+
+public class SportName(string value) : SemanticTagBaseValue("sportName", value)
 {
-    public class SportName : SemanticTagBaseValue
-    {
-        public SportName(string value) : base("sportName", value)
-        {
-            // NO OP
-        }
-    }
 }

--- a/Passbook.Generator/Tags/totalPrice.cs
+++ b/Passbook.Generator/Tags/totalPrice.cs
@@ -1,25 +1,16 @@
-﻿using Newtonsoft.Json;
+﻿using System.Text.Json;
 
 namespace Passbook.Generator.Tags
 {
-    public class TotalPrice : SemanticTag
+    public class TotalPrice(string amount, string currencyCode) : SemanticTag("totalPrice")
     {
-        private readonly string _amount;
-        private readonly string _currencyCode;
-
-        public TotalPrice(string amount, string currencyCode) : base("totalPrice")
-        {
-            _amount = amount;
-            _currencyCode = currencyCode;
-        }
-
-        public override void WriteValue(JsonWriter writer)
+        public override void WriteValue(Utf8JsonWriter writer)
         {
             writer.WriteStartObject();
             writer.WritePropertyName("amount");
-            writer.WriteValue(_amount);
+            writer.WriteStringValue(amount);
             writer.WritePropertyName("currencyCode");
-            writer.WriteValue(_currencyCode);
+            writer.WriteStringValue(currencyCode);
             writer.WriteEndObject();
         }
     }

--- a/Passbook.Generator/Tags/transitProvider.cs
+++ b/Passbook.Generator/Tags/transitProvider.cs
@@ -1,10 +1,5 @@
-﻿namespace Passbook.Generator.Tags
+﻿namespace Passbook.Generator.Tags;
+
+public class TransitProvider(string value) : SemanticTagBaseValue("transitProvider", value)
 {
-    public class TransitProvider : SemanticTagBaseValue
-    {
-        public TransitProvider(string value) : base("transitProvider", value)
-        {
-            // NO OP
-        }
-    }
 }

--- a/Passbook.Generator/Tags/transitStatus.cs
+++ b/Passbook.Generator/Tags/transitStatus.cs
@@ -1,10 +1,5 @@
-﻿namespace Passbook.Generator.Tags
+﻿namespace Passbook.Generator.Tags;
+
+public class TransitStatus(string value) : SemanticTagBaseValue("transitStatus", value)
 {
-    public class TransitStatus : SemanticTagBaseValue
-    {
-        public TransitStatus(string value) : base("transitStatus", value)
-        {
-            // NO OP
-        }
-    }
 }

--- a/Passbook.Generator/Tags/transitStatusReason.cs
+++ b/Passbook.Generator/Tags/transitStatusReason.cs
@@ -1,10 +1,5 @@
-﻿namespace Passbook.Generator.Tags
+﻿namespace Passbook.Generator.Tags;
+
+public class TransitStatusReason(string value) : SemanticTagBaseValue("transitStatusReason", value)
 {
-    public class TransitStatusReason : SemanticTagBaseValue
-    {
-        public TransitStatusReason(string value) : base("transitStatusReason", value)
-        {
-            // NO OP
-        }
-    }
 }

--- a/Passbook.Generator/Tags/vehicleName.cs
+++ b/Passbook.Generator/Tags/vehicleName.cs
@@ -1,10 +1,5 @@
-﻿namespace Passbook.Generator.Tags
+﻿namespace Passbook.Generator.Tags;
+
+public class VehicleName(string value) : SemanticTagBaseValue("vehicleName", value)
 {
-    public class VehicleName : SemanticTagBaseValue
-    {
-        public VehicleName(string value) : base("vehicleName", value)
-        {
-            // NO OP
-        }
-    }
 }

--- a/Passbook.Generator/Tags/vehicleNumber.cs
+++ b/Passbook.Generator/Tags/vehicleNumber.cs
@@ -1,10 +1,5 @@
-﻿namespace Passbook.Generator.Tags
+﻿namespace Passbook.Generator.Tags;
+
+public class VehicleNumber(string value) : SemanticTagBaseValue("vehicleNumber", value)
 {
-    public class VehicleNumber : SemanticTagBaseValue
-    {
-        public VehicleNumber(string value) : base("vehicleNumber", value)
-        {
-            // NO OP
-        }
-    }
 }

--- a/Passbook.Generator/Tags/vehicleType.cs
+++ b/Passbook.Generator/Tags/vehicleType.cs
@@ -1,10 +1,5 @@
-﻿namespace Passbook.Generator.Tags
+﻿namespace Passbook.Generator.Tags;
+
+public class VehicleType(string value) : SemanticTagBaseValue("vehicleType", value)
 {
-    public class VehicleType : SemanticTagBaseValue
-    {
-        public VehicleType(string value) : base("vehicleType", value)
-        {
-            // NO OP
-        }
-    }
 }

--- a/Passbook.Generator/Tags/venueEntrance.cs
+++ b/Passbook.Generator/Tags/venueEntrance.cs
@@ -1,10 +1,5 @@
-﻿namespace Passbook.Generator.Tags
+﻿namespace Passbook.Generator.Tags;
+
+public class VenueEntrance(string value) : SemanticTagBaseValue("venueEntrance", value)
 {
-    public class VenueEntrance : SemanticTagBaseValue
-    {
-        public VenueEntrance(string value) : base("venueEntrance", value)
-        {
-            // NO OP
-        }
-    }
 }

--- a/Passbook.Generator/Tags/venueLocation.cs
+++ b/Passbook.Generator/Tags/venueLocation.cs
@@ -1,26 +1,16 @@
-﻿using Newtonsoft.Json;
+﻿using System.Text.Json;
 
-namespace Passbook.Generator.Tags
+namespace Passbook.Generator.Tags;
+
+public class VenueLocation(double latitude, double longitude) : SemanticTag("venueLocation")
 {
-    public class VenueLocation : SemanticTag
+    public override void WriteValue(Utf8JsonWriter writer)
     {
-        private readonly double _latitude;
-        private readonly double _longitude;
-
-        public VenueLocation(double latitude, double longitude) : base("venueLocation")
-        {
-            _latitude = latitude;
-            _longitude = longitude;
-        }
-
-        public override void WriteValue(JsonWriter writer)
-        {
-            writer.WriteStartObject();
-            writer.WritePropertyName("latitude");
-            writer.WriteValue(_latitude);
-            writer.WritePropertyName("longitude");
-            writer.WriteValue(_longitude);
-            writer.WriteEndObject();
-        }
+        writer.WriteStartObject();
+        writer.WritePropertyName("latitude");
+        writer.WriteNumberValue(latitude);
+        writer.WritePropertyName("longitude");
+        writer.WriteNumberValue(longitude);
+        writer.WriteEndObject();
     }
 }

--- a/Passbook.Generator/Tags/venueName.cs
+++ b/Passbook.Generator/Tags/venueName.cs
@@ -1,10 +1,5 @@
-﻿namespace Passbook.Generator.Tags
+﻿namespace Passbook.Generator.Tags;
+
+public class VenueName(string value) : SemanticTagBaseValue("venueName", value)
 {
-    public class VenueName : SemanticTagBaseValue
-    {
-        public VenueName(string value) : base("venueName", value)
-        {
-            // NO OP
-        }
-    }
 }

--- a/Passbook.Generator/Tags/venuePhoneNumber.cs
+++ b/Passbook.Generator/Tags/venuePhoneNumber.cs
@@ -1,10 +1,5 @@
-﻿namespace Passbook.Generator.Tags
+﻿namespace Passbook.Generator.Tags;
+
+public class VenuePhoneNumber(string value) : SemanticTagBaseValue("venuePhoneNumber", value)
 {
-    public class VenuePhoneNumber : SemanticTagBaseValue
-    {
-        public VenuePhoneNumber(string value) : base("venuePhoneNumber", value)
-        {
-            // NO OP
-        }
-    }
 }

--- a/Passbook.Generator/Tags/venueRoom.cs
+++ b/Passbook.Generator/Tags/venueRoom.cs
@@ -1,10 +1,5 @@
-﻿namespace Passbook.Generator.Tags
+﻿namespace Passbook.Generator.Tags;
+
+public class VenueRoom(string value) : SemanticTagBaseValue("venueRoom", value)
 {
-    public class VenueRoom : SemanticTagBaseValue
-    {
-        public VenueRoom(string value) : base("venueRoom", value)
-        {
-            // NO OP
-        }
-    }
 }

--- a/Passbook.Generator/Tags/wifiAccess.cs
+++ b/Passbook.Generator/Tags/wifiAccess.cs
@@ -1,26 +1,16 @@
-﻿using Newtonsoft.Json;
+﻿using System.Text.Json;
 
-namespace Passbook.Generator.Tags
+namespace Passbook.Generator.Tags;
+
+public class WifiAccess(string ssid, string password) : SemanticTag("wifiAccess")
 {
-    public class WifiAccess : SemanticTag
+    public override void WriteValue(Utf8JsonWriter writer)
     {
-        private readonly string _ssid;
-        private readonly string _password;
-
-        public WifiAccess(string ssid, string password) : base("wifiAccess")
-        {
-            _ssid = ssid;
-            _password = password;
-        }
-
-        public override void WriteValue(JsonWriter writer)
-        {
-            writer.WriteStartObject();
-            writer.WritePropertyName("password");
-            writer.WriteValue(_ssid);
-            writer.WritePropertyName("ssid");
-            writer.WriteValue(_password);
-            writer.WriteEndObject();
-        }
+        writer.WriteStartObject();
+        writer.WritePropertyName("ssid");
+        writer.WriteStringValue(ssid);
+        writer.WritePropertyName("password");
+        writer.WriteStringValue(password);
+        writer.WriteEndObject();
     }
 }

--- a/Passbook.Generator/TransitType.cs
+++ b/Passbook.Generator/TransitType.cs
@@ -1,11 +1,10 @@
-﻿namespace Passbook.Generator
+﻿namespace Passbook.Generator;
+
+public enum TransitType
 {
-    public enum TransitType
-    {
-        PKTransitTypeAir,
-        PKTransitTypeBoat,
-        PKTransitTypeBus,
-        PKTransitTypeGeneric,
-        PKTransitTypeTrain
-    }
+    PKTransitTypeAir,
+    PKTransitTypeBoat,
+    PKTransitTypeBus,
+    PKTransitTypeGeneric,
+    PKTransitTypeTrain
 }


### PR DESCRIPTION
- use file-scoped namespace declarations;
- use primary constructors in tags;
- convert `using` statements to declarations;
- remove `Newtonsoft.Json` dependency in favor of `System.Text.Json`;
- add `<IsTestProject>` to tests project;
- remove `this.` keyword when assigning values;
- move away from obsolete encryption types;