### PR TITLE
Add `IPassGenerator` interface for DI and testing

### DIFF
--- a/Passbook.Generator/IPassGenerator.cs
+++ b/Passbook.Generator/IPassGenerator.cs
@@ -1,0 +1,23 @@
+public interface IPassGenerator
+{
+    /// <summary>
+    /// Creates a byte array which contains one pkpass file
+    /// </summary>
+    /// <param name="generatorRequest">
+    /// An instance of a PassGeneratorRequest</param>
+    /// <returns>
+    /// A byte array which contains a zipped pkpass file.
+    /// </returns>
+    public byte[] Generate(PassGeneratorRequest generatorRequest);
+
+    /// <summary>
+    /// Creates a byte array that can contains a .pkpasses file for bundling multiple passes together
+    /// </summary>
+    /// <param name="generatorRequests">
+    /// A list of PassGeneratorRequest objects
+    /// </param>
+    /// <returns>
+    /// A byte array which contains a zipped pkpasses file.
+    /// </returns>
+    public byte[] Generate(IReadOnlyList<PassGeneratorRequest> generatorRequests);
+}

--- a/Passbook.Generator/IPassGenerator.cs
+++ b/Passbook.Generator/IPassGenerator.cs
@@ -1,3 +1,7 @@
+using System.Collections.Generic;
+
+namespace Passbook.Generator;
+
 public interface IPassGenerator
 {
     /// <summary>

--- a/Passbook.Generator/PassGenerator.cs
+++ b/Passbook.Generator/PassGenerator.cs
@@ -14,7 +14,7 @@ using System.Text.RegularExpressions;
 
 namespace Passbook.Generator;
 
-public class PassGenerator
+public class PassGenerator: IPassGenerator
 {
     private byte[] passFile = null;
     private byte[] signatureFile = null;
@@ -24,14 +24,6 @@ public class PassGenerator
     private byte[] pkPassBundle = null;
     private const string passTypePrefix = "Pass Type ID: ";
 
-    /// <summary>
-    /// Creates a byte array which contains one pkpass file
-    /// </summary>
-    /// <param name="generatorRequest">
-    /// An instance of a PassGeneratorRequest</param>
-    /// <returns>
-    /// A byte array which contains a zipped pkpass file.
-    /// </returns>
     /// <exception cref="ArgumentNullException"></exception>
     public byte[] Generate(PassGeneratorRequest generatorRequest)
     {
@@ -46,15 +38,6 @@ public class PassGenerator
         return pkPassFile;
     }
 
-    /// <summary>
-    /// Creates a byte array that can contains a .pkpasses file for bundling multiple passes together 
-    /// </summary>
-    /// <param name="generatorRequests">
-    /// A list of PassGeneratorRequest objects
-    /// </param>
-    /// <returns>
-    /// A byte array which contains a zipped pkpasses file.
-    /// </returns>
     /// <exception cref="System.ArgumentNullException">
     /// <exception cref="System.ArgumentException">
     public byte[] Generate(IReadOnlyList<PassGeneratorRequest> generatorRequests)


### PR DESCRIPTION
Conform to the `IPassGenerator` interface in `PassGenerator` to allow for dependency injection and testing.

Write a simple section in README to explain the purpose of the interface and how to use it.